### PR TITLE
feat(#43): complete TypeScript migration for useGoalForm and related …

### DIFF
--- a/frontend/src/hooks/useGoalForm.ts
+++ b/frontend/src/hooks/useGoalForm.ts
@@ -4,39 +4,42 @@ import { defaultGoalFormValues, goalFormSchema } from '../schemas/goalSchema';
 import { handleApiError } from '../services/errorHandler';
 import { getExerciseType } from '../services/exerciseService';
 import { goalAPI } from '../services/goalApi';
+import { SimpleAppError } from '../types/error';
+import type { GoalFormData, GoalSubmitData } from '../types/form';
 import { useFeedback } from './useFeedback';
 
-const useGoalForm = () => {
-  const { feedback, showFeedback } = useFeedback();
 
-  const form = useForm({
-    resolver: yupResolver(goalFormSchema),
+
+const useGoalForm = () => {
+  const form = useForm<GoalFormData>({
+    resolver: yupResolver(goalFormSchema) as any,
     defaultValues: defaultGoalFormValues
   });
 
-  const submitGoal = async (data) => {
+  const { feedback, showFeedback } = useFeedback();
+
+  const submitGoal = async (data: GoalFormData): Promise<void> => {
     try {
-      const submitData = {
+      const submitData: GoalSubmitData = {
         exercise: data.exercise,
-        exerciseType: getExerciseType(data.exercise),
-        targetAmount: parseInt(data.targetAmount, 10),
+        exerciseType: getExerciseType(data.exercise) as 'strength' | 'cardio',
+        targetAmount: data.targetAmount,
         metricUnit: 'reps',
       };
-
-      console.log('🚀 目標作成開始:', submitData);
       const result = await goalAPI.createGoal(submitData);
-      console.log('✅ 目標作成成功:', result);
       showFeedback(result.message || '目標設定が完了しました', 'success');
       form.reset();
-    } catch (error) {
+    } catch (error: unknown) {
       console.log('❌ エラーキャッチ:', error);
       try {
         handleApiError(error);
-      } catch (processedError) {
+      } catch (processedError: unknown) {
+        if (processedError instanceof SimpleAppError) {
         console.log('⚡ 処理後エラー:', processedError);
         console.log('📝 エラータイプ:', processedError.type);
         console.log('💬 ユーザーメッセージ:', processedError.message);
         showFeedback(processedError.message, 'error');
+        }
       }
     }
   };
@@ -45,7 +48,7 @@ const useGoalForm = () => {
     ...form,
     submitGoal,
     feedback
-  }
-}
+  };
+};
 
-export default useGoalForm
+export default useGoalForm;

--- a/frontend/src/schemas/goalSchema.ts
+++ b/frontend/src/schemas/goalSchema.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import type { GoalFormData } from '../types/form';
 
 export const goalFormSchema = yup.object().shape({
   exercise: yup.string().required('トレーニング種目を選択してください'),
@@ -7,7 +8,7 @@ export const goalFormSchema = yup.object().shape({
     .min(1, '1回以上入力してください'),
 });
 
-export const defaultGoalFormValues = {
+export const defaultGoalFormValues: GoalFormData = {
   exercise: '',
-  targetAmount: '',
+  targetAmount: 0,
 };

--- a/frontend/src/services/exerciseService.ts
+++ b/frontend/src/services/exerciseService.ts
@@ -2,7 +2,7 @@ import { EXERCISE_OPTIONS, WORKOUT_TYPES } from '../config/exercise';
 
 // 運動関連のビジネスロジックを分離
 
-const getExerciseType = (exerciseName) => {
+const getExerciseType = (exerciseName: string): string => {
   const exercise = EXERCISE_OPTIONS.find(exercise => exercise.name === exerciseName);
   return exercise ? exercise.type : WORKOUT_TYPES.STRENGTH;
 };

--- a/frontend/src/services/goalApi.ts
+++ b/frontend/src/services/goalApi.ts
@@ -1,12 +1,13 @@
 import { Goal } from '../types';
+import { GoalCreateData } from '../types/form';
 import apiClient from './api';
 
 export const goalAPI = {
-
-  async createGoal(goal: Goal): Promise<{message: string, goal: Goal}> {
+  async createGoal(goalData: GoalCreateData): Promise<{message: string, goal: Goal}> {
     try {
       console.log("📡 API Call: POST /goals");
-      const response = await apiClient.post<{message: string, goal: Goal}>('/goals', goal);
+      const response = await apiClient.post<{message: string, goal: Goal}>('/goals', goalData);
+      console.log("✅ API成功:", response.data);
       return response.data;
     } catch (error) {
       console.error('目標作成エラー:', error);

--- a/frontend/src/types/form.ts
+++ b/frontend/src/types/form.ts
@@ -1,0 +1,15 @@
+export interface GoalFormData {
+  exercise: string;
+  targetAmount: number;
+  [key: string]: any;
+}
+
+export interface GoalCreateData {
+  exercise: string;
+  exerciseType: 'strength' | 'cardio';
+  targetAmount: number;
+  metricUnit: 'reps'
+}
+
+// 後方互換性のためのエイリアス
+export type GoalSubmitData = GoalCreateData;

--- a/frontend/src/types/goal.ts
+++ b/frontend/src/types/goal.ts
@@ -1,11 +1,9 @@
 export interface Goal {
-  readonly id: number;          // readonly: 変更不可
-  userID: number;
-  exercise: string;
-  exerciseType: 'strength' | 'cardio';  // Union型: どちらかのみ
+ exercise: string;
+  exerciseType: 'strength' | 'cardio';  
   targetAmount: number;
-  progressAmount: number;
-  metricUnit: 'reps' | 'minutes' | 'km';
+  progressAmount: 0;
+  metricUnit: 'reps';
   status: 'in_progress' | 'completed';
   createdAt: string;
   updatedAt: string;
@@ -13,14 +11,7 @@ export interface Goal {
 
 
 
-// ============================================================================
-// Computed Types - 計算されるプロパティの型定義
-// ============================================================================
 
-/**
- * 進捗計算結果の型
- * UIコンポーネントでの表示最適化
- */
 export interface GoalProgress {
   percentage: number;                     // 進捗率（0-100）
   remaining: number;                      // 残り数量
@@ -29,13 +20,6 @@ export interface GoalProgress {
   completionRate: number;                 // 達成率（100%超過可能）
 }
 
-
-
-
-/**
- * 目標カードコンポーネントのProps型
- * 再利用可能コンポーネント設計
- */
 export interface GoalCardProps {
   goal: Goal;                 // 表示する目標データ
   onProgressUpdate: (goalId: number, amount: number) => Promise<void>;
@@ -45,14 +29,7 @@ export interface GoalCardProps {
   showDetailedProgress?: boolean;         // 詳細進捗表示フラグ
 }
 
-// ============================================================================
-// API Response Types - API通信用型定義
-// ============================================================================
 
-/**
- * API共通レスポンス型
- * 一貫したAPIレスポンス構造
- */
 export interface ApiResponse<T> {
   data: T;                                // レスポンスデータ
   message: string;                        // 操作結果メッセージ


### PR DESCRIPTION
- useGoalForm.jsのTypeScript移行
- goalSchema.js・exerciseService.jsのTypeScript変換
- API型安全性確保のGoalCreateDataインターフェース実装
- goalApi.tsのリクエスト・レスポンス型改善
- types/form.tsでフォーム型定義追加
- SimpleAppErrorによる型安全エラーハンドリング強化
- types/goal.tsの重複型定義削除