### PR TITLE
fix(#54): ワークアウト履歴テーブルのデータ表示問題を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import './App.css';
 import { AuthContextProvider } from './components/AuthContext';
 import Login from './components/Login';
@@ -16,15 +16,33 @@ function App() {
       <AuthContextProvider>
         <Navbar />
         <Routes>
-          <Route path='/dashboard' element={<PrivateRoute element={<DashboadPage />} />} />
-          <Route path='/' element={<PrivateRoute element={<WorkoutFormPage />} />} />
-          <Route path='/workout-history' element={<PrivateRoute element={<WorkoutHistory />} />} />
-          <Route path='/workout-history' element={<PrivateRoute element={<WorkoutHistory />} />} />
-          <Route path='/signup' element={<PublicRoute element={<Register />} restricted={true} />} />
-          <Route path='/login' element={<PublicRoute element={<Login />} restricted={true} />} />
+          <Route
+            path="/dashboard"
+            element={<PrivateRoute element={<DashboadPage />} />}
+          />
+          <Route
+            path="/"
+            element={<PrivateRoute element={<WorkoutFormPage />} />}
+          />
+          <Route
+            path="/workout-history"
+            element={<PrivateRoute element={<WorkoutHistory />} />}
+          />
+          <Route
+            path="/workout-history"
+            element={<PrivateRoute element={<WorkoutHistory />} />}
+          />
+          <Route
+            path="/signup"
+            element={<PublicRoute element={<Register />} restricted={true} />}
+          />
+          <Route
+            path="/login"
+            element={<PublicRoute element={<Login />} restricted={true} />}
+          />
 
           {/* ログアウトルート - 誰でもアクセス可能 */}
-          <Route path='/logout' element={<Logout />} />
+          <Route path="/logout" element={<Logout />} />
         </Routes>
       </AuthContextProvider>
     </Router>

--- a/frontend/src/components/AuthContext.tsx
+++ b/frontend/src/components/AuthContext.tsx
@@ -11,12 +11,14 @@ import {
   LoginCredentials,
   LoginResponse,
   RefreshTokenResponse,
-  User
+  User,
 } from '../types/auth';
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX.Element => {
+export const AuthContextProvider = ({
+  children,
+}: AuthContextProviderProps): JSX.Element => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -24,7 +26,7 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
     if (token) {
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     } else {
-      delete axios.defaults.headers.common['Authorization']
+      delete axios.defaults.headers.common['Authorization'];
     }
   };
 
@@ -36,7 +38,9 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
 
   const refreshToken = useCallback(async (): Promise<boolean> => {
     try {
-      const res: AxiosResponse<RefreshTokenResponse> = await axios.post('http://localhost:8000/authrouter/refresh-token');
+      const res: AxiosResponse<RefreshTokenResponse> = await axios.post(
+        'http://localhost:8000/authrouter/refresh-token'
+      );
       const { token } = res.data;
       localStorage.setItem('token', token);
       setAuthToken(token);
@@ -52,10 +56,15 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
             console.error('認証エラー: トークンの期限が切れています');
             break;
           case 500:
-            console.error('サーバーエラー: サーバーが予期せぬエラーを返しました');
+            console.error(
+              'サーバーエラー: サーバーが予期せぬエラーを返しました'
+            );
             break;
           default:
-            console.error(`トークン更新エラー (${error.response.status}):`, error.response.data);
+            console.error(
+              `トークン更新エラー (${error.response.status}):`,
+              error.response.data
+            );
         }
       } else if (error instanceof AxiosError && error.request) {
         console.error('サーバー応答なし:', error.request);
@@ -85,7 +94,7 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
           console.error('トークン検証エラー:', error.message);
         } else {
           console.error('未知のエラー:', error);
-        } 
+        }
         logout();
       }
     }
@@ -99,7 +108,9 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
     }
     setAuthToken(token);
     try {
-      const res: AxiosResponse<User> = await axios.get('http://localhost:8000/authrouter/me');
+      const res: AxiosResponse<User> = await axios.get(
+        'http://localhost:8000/authrouter/me'
+      );
       console.log('ユーザーデータ取得成功:', res.data);
       setUser(res.data);
     } catch (error: unknown) {
@@ -125,10 +136,16 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
             console.error('エンドポイントエラー: /me が見つかりません');
             break;
           default:
-            console.error(`サーバーエラー (${error.response.status}):`, error.response.data);
+            console.error(
+              `サーバーエラー (${error.response.status}):`,
+              error.response.data
+            );
         }
       } else if (error instanceof AxiosError && error.request) {
-        console.error('サーバー応答なし。接続を確認してください:', error.request);
+        console.error(
+          'サーバー応答なし。接続を確認してください:',
+          error.request
+        );
       } else if (error instanceof Error) {
         console.error('リクエスト設定エラー:', error.message);
       } else {
@@ -148,7 +165,10 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
 
   const login = async (credentials: LoginCredentials): Promise<User> => {
     try {
-      const res: AxiosResponse<LoginResponse> = await axios.post('http://localhost:8000/authrouter/login', credentials);
+      const res: AxiosResponse<LoginResponse> = await axios.post(
+        'http://localhost:8000/authrouter/login',
+        credentials
+      );
       const { token, user } = res.data;
       localStorage.setItem('token', token);
       setAuthToken(token);
@@ -156,7 +176,6 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
       return user;
     } catch (error: unknown) {
       if (error instanceof AxiosError && error.response) {
-
         switch (error.response.status) {
           case 401:
             console.error('認証エラー: ユーザー名またはパスワードが無効です');
@@ -165,14 +184,19 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
             console.error('エンドポイントエラー: /login が見つかりません');
             break;
           case 500:
-            console.error('サーバーエラー: サーバーが予期せぬエラーを返しました');
+            console.error(
+              'サーバーエラー: サーバーが予期せぬエラーを返しました'
+            );
             break;
           default:
-            console.error(`ログインエラー (${error.response.status}):`, error.response.data);
+            console.error(
+              `ログインエラー (${error.response.status}):`,
+              error.response.data
+            );
         }
       } else if (error instanceof AxiosError && error.request) {
         console.error('サーバー応答なし:', error.request);
-      } else if (error instanceof Error) {  
+      } else if (error instanceof Error) {
         console.error('リクエスト設定エラー:', error.message);
       } else {
         console.error('未知のエラー:', error);
@@ -191,12 +215,14 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps): JSX
   }, [user, checkTokenExpiration]);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, loading, refreshToken }}>
+    <AuthContext.Provider
+      value={{ user, login, logout, loading, refreshToken }}
+    >
       {children}
     </AuthContext.Provider>
-  )
-}
+  );
+};
 
 AuthContextProvider.propTypes = {
-  children: PropTypes.node.isRequired
-}
+  children: PropTypes.node.isRequired,
+};

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,9 +1,5 @@
-
-
 const Dashboard = () => {
-  return (
-    <div>Dashboard</div>
-  )
-}
+  return <div>Dashboard</div>;
+};
 
-export default Dashboard
+export default Dashboard;

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,5 +1,4 @@
-
-import { useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { useAuth } from './Hook';
@@ -15,7 +14,7 @@ const Login = () => {
     formState: { errors },
   } = useForm();
 
-  const onSubmit = async (data) => {
+  const onSubmit = async data => {
     try {
       await login(data);
       navigate('/dashboard');
@@ -29,34 +28,42 @@ const Login = () => {
       }
       console.error('ログインエラー', error);
     }
-  }
+  };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div>
-        <input type="text" placeholder="Email" {...register('email', {
-          required: 'Email is required',
-          pattern: {
-            value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-            message: '有効なメールアドレスを入力してください',
-          },
-        })} />
+        <input
+          type="text"
+          placeholder="Email"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: '有効なメールアドレスを入力してください',
+            },
+          })}
+        />
         {errors.email && <p>{errors.email.message}</p>}
       </div>
       <div>
-        <input type="password" placeholder="Password" {...register('password', {
-          required: 'Password is required',
-          minLength: {
-            value: 8,
-            message: 'パスワードは8文字以上で入力してください',
-          },
-        })} />
+        <input
+          type="password"
+          placeholder="Password"
+          {...register('password', {
+            required: 'Password is required',
+            minLength: {
+              value: 8,
+              message: 'パスワードは8文字以上で入力してください',
+            },
+          })}
+        />
         {errors.password && <p>{errors.password.message}</p>}
       </div>
 
       <button type="submit">ログイン</button>
-      {errorMessage && <p className='error-message'>{errorMessage}</p>}
+      {errorMessage && <p className="error-message">{errorMessage}</p>}
     </form>
-  )
-}
-export default Login
+  );
+};
+export default Login;

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -11,9 +11,7 @@ const Logout = () => {
     navigate('/login');
   }, [logout, navigate]);
 
-  return (
-    <div>ログアウト中...</div>
-  )
-}
+  return <div>ログアウト中...</div>;
+};
 
-export default Logout
+export default Logout;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,30 +1,30 @@
-import { Link } from 'react-router-dom'
-import { useAuth } from './Hook'
+import { Link } from 'react-router-dom';
+import { useAuth } from './Hook';
 
 const Navbar = () => {
-  const { user, loading } = useAuth()
+  const { user, loading } = useAuth();
 
   return (
     <nav>
-
       {!loading && (
         <>
           {user ? (
             <>
-              <Link to='/dashboard'>ダッシュボード</Link>
-              <Link to='/'>ワークアウトフォーム</Link>
-              <Link to='/workout-history'>ワークアウト履歴</Link>
-              <Link to='/logout'>ログアウト</Link>
+              <Link to="/dashboard">ダッシュボード</Link>
+              <Link to="/">ワークアウトフォーム</Link>
+              <Link to="/workout-history">ワークアウト履歴</Link>
+              <Link to="/logout">ログアウト</Link>
             </>
           ) : (
             <>
-              <Link to='/login'>ログイン</Link>
-              <Link to='/signup'>サインアップ</Link>            </>
+              <Link to="/login">ログイン</Link>
+              <Link to="/signup">サインアップ</Link>{' '}
+            </>
           )}
         </>
       )}
     </nav>
-  )
-}
+  );
+};
 
-export default Navbar
+export default Navbar;

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -17,7 +17,7 @@ const PrivateRoute = ({ element }) => {
 };
 
 PrivateRoute.propTypes = {
-  element: PropTypes.node.isRequired
+  element: PropTypes.node.isRequired,
 };
 
-export default PrivateRoute; 
+export default PrivateRoute;

--- a/frontend/src/components/PublicRoute.jsx
+++ b/frontend/src/components/PublicRoute.jsx
@@ -18,7 +18,7 @@ const PublicRoute = ({ element, restricted = false }) => {
 
 PublicRoute.propTypes = {
   element: PropTypes.node.isRequired,
-  restricted: PropTypes.bool
+  restricted: PropTypes.bool,
 };
 
-export default PublicRoute; 
+export default PublicRoute;

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -1,8 +1,7 @@
-import { useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form';
 import axios from 'axios';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 
 const Register = () => {
   const [errorMessage, setErrorMessage] = useState(null);
@@ -14,7 +13,7 @@ const Register = () => {
     formState: { errors },
   } = useForm();
 
-  const onSubmit = async (data) => {
+  const onSubmit = async data => {
     try {
       await axios.post('http://localhost:8000/authrouter/register', {
         username: data.username,
@@ -31,62 +30,73 @@ const Register = () => {
         } else if (error.response.status === 404) {
           setErrorMessage('リソースが見つかりません。');
         } else if (error.response.status >= 500) {
-          setErrorMessage('サーバーエラーが発生しました。後でもう一度お試しください。');
+          setErrorMessage(
+            'サーバーエラーが発生しました。後でもう一度お試しください。'
+          );
         }
       } else if (error.request) {
-        setErrorMessage('サーバーに接続できません。インターネット接続を確認してください。');
+        setErrorMessage(
+          'サーバーに接続できません。インターネット接続を確認してください。'
+        );
       } else {
         setErrorMessage('予期しないエラーが発生しました。');
       }
     }
-  }
-
+  };
 
   return (
-    <div className='signupForm'>
+    <div className="signupForm">
       <h1>ユーザー登録</h1>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div>
-          <label htmlFor='username'>Username</label>
-          <input id="username" {...register('username', {
-            required: 'ユーザー名は必須です',
-            minLength: {
-              value: 3,
-              message: 'ユーザー名は3文字以上で入力してください',
-            },
-          })} />
+          <label htmlFor="username">Username</label>
+          <input
+            id="username"
+            {...register('username', {
+              required: 'ユーザー名は必須です',
+              minLength: {
+                value: 3,
+                message: 'ユーザー名は3文字以上で入力してください',
+              },
+            })}
+          />
           {errors.username && <p>{errors.username.message}</p>}
         </div>
         <div>
-          <label htmlFor='email'>Email</label>
-          <input id="email" {...register('email', {
-            required: 'メールアドレスは必須です',
-            pattern: {
-              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-              message: '有効なメールアドレスを入力してください',
-            },
-          })} />
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            {...register('email', {
+              required: 'メールアドレスは必須です',
+              pattern: {
+                value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                message: '有効なメールアドレスを入力してください',
+              },
+            })}
+          />
           {errors.email && <p>{errors.email.message}</p>}
         </div>
 
         <div>
-          <label htmlFor='password'>Password</label>
-          <input id="password" {...register('password', {
-            required: 'パスワードは必須です',
-            minLength: {
-              value: 8,
-              message: 'パスワードは8文字以上で入力してください',
-            },
-          })} type='password' />
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            {...register('password', {
+              required: 'パスワードは必須です',
+              minLength: {
+                value: 8,
+                message: 'パスワードは8文字以上で入力してください',
+              },
+            })}
+            type="password"
+          />
           {errors.password && <p>{errors.password.message}</p>}
         </div>
-        <button type='submit'>アカウント作成</button>
-        {errorMessage && <p className='error-message'>{errorMessage}</p>}
+        <button type="submit">アカウント作成</button>
+        {errorMessage && <p className="error-message">{errorMessage}</p>}
       </form>
-
     </div>
-  )
-}
+  );
+};
 
-
-export default Register
+export default Register;

--- a/frontend/src/components/WorkoutCustomizationDrawer.jsx
+++ b/frontend/src/components/WorkoutCustomizationDrawer.jsx
@@ -51,9 +51,9 @@ const WorkoutCustomizationDrawer = ({
   console.log(availableToAdd);
 
   return (
-    <Drawer 
-      anchor='right' 
-      open={open} 
+    <Drawer
+      anchor="right"
+      open={open}
       onClose={onClose}
       sx={{
         '& .MuiDrawer-paper': {
@@ -64,14 +64,16 @@ const WorkoutCustomizationDrawer = ({
     >
       <Box sx={{ p: 2 }}>
         {/* ヘッダー */}
-        <Box sx={{ 
-          display: 'flex', 
-          alignItems: 'center', 
-          justifyContent: 'space-between',
-          p: 2,
-          borderBottom: '1px solid',
-          borderColor: 'divider'
-        }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            p: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
           <Typography variant="h6" component="h2">
             ワークアウトカスタマイズ設定
           </Typography>
@@ -84,24 +86,22 @@ const WorkoutCustomizationDrawer = ({
         <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
           {/* プリセットセクション - 折りたたみ式 */}
           <Box sx={{ mb: 2 }}>
-            <Box 
-              sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
                 justifyContent: 'space-between',
                 cursor: 'pointer',
                 py: 1,
                 borderRadius: 1,
                 '&:hover': {
-                  bgcolor: 'action.hover'
-                }
+                  bgcolor: 'action.hover',
+                },
               }}
               onClick={handlePresetToggle}
             >
               <Box>
-                <Typography variant="subtitle1">
-                  プリセット
-                </Typography>
+                <Typography variant="subtitle1">プリセット</Typography>
                 <Typography variant="body2" color="text.secondary">
                   よく使われる設定から選択
                 </Typography>
@@ -110,7 +110,7 @@ const WorkoutCustomizationDrawer = ({
                 size="small"
                 sx={{
                   transform: presetExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                  transition: 'transform 0.3s ease'
+                  transition: 'transform 0.3s ease',
                 }}
               >
                 <ExpandMoreIcon />
@@ -120,19 +120,20 @@ const WorkoutCustomizationDrawer = ({
             <Collapse in={presetExpanded} timeout="auto" unmountOnExit>
               <Box sx={{ mt: 2 }}>
                 {Object.entries(presets).map(([key, preset]) => {
-                  const cardioCount = preset.exercises.filter(isCardioExercise).length;
+                  const cardioCount =
+                    preset.exercises.filter(isCardioExercise).length;
                   const strengthCount = preset.exercises.length - cardioCount;
-                  return(
+                  return (
                     <Card
-                      key={key} 
-                      variant="outlined" 
-                      sx={{ 
+                      key={key}
+                      variant="outlined"
+                      sx={{
                         cursor: 'pointer',
                         mb: 1,
-                        '&:hover': { 
+                        '&:hover': {
                           borderColor: 'primary.main',
-                          bgcolor: 'primary.50' 
-                        }
+                          bgcolor: 'primary.50',
+                        },
                       }}
                       onClick={() => applyPreset(key)}
                     >
@@ -143,9 +144,16 @@ const WorkoutCustomizationDrawer = ({
                         <Typography variant="body2" color="text.secondary">
                           {preset.exercises.join(', ')}
                         </Typography>
-                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            gap: 1,
+                            flexWrap: 'wrap',
+                            mt: 1,
+                          }}
+                        >
                           {cardioCount > 0 && (
-                            <Chip 
+                            <Chip
                               icon={<RunIcon />}
                               label={`カーディオ ${cardioCount}種目`}
                               size="small"
@@ -153,7 +161,7 @@ const WorkoutCustomizationDrawer = ({
                             />
                           )}
                           {strengthCount > 0 && (
-                            <Chip 
+                            <Chip
                               icon={<FitnessCenterIcon />}
                               label={`筋トレ ${strengthCount}種目 (${preset.maxSets}セット)`}
                               size="small"
@@ -190,17 +198,17 @@ const WorkoutCustomizationDrawer = ({
                       <FitnessCenterIcon color="primary" fontSize="small" />
                     )}
                   </Box>
-                  <ListItemText 
+                  <ListItemText
                     primary={exercise}
                     secondary={
-                      isCardioExercise(exercise) 
-                        ? 'カーディオ' 
+                      isCardioExercise(exercise)
+                        ? 'カーディオ'
                         : `筋トレ (${workoutConfig.maxSets}セット)`
                     }
                   />
                   <ListItemSecondaryAction>
-                    <IconButton 
-                      edge="end" 
+                    <IconButton
+                      edge="end"
                       size="small"
                       onClick={() => removeExercise(exercise)}
                       color="error"
@@ -223,7 +231,7 @@ const WorkoutCustomizationDrawer = ({
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               筋トレ種目の最大セット数を設定
             </Typography>
-            
+
             <Box sx={{ px: 2 }}>
               <Typography variant="body2" gutterBottom>
                 最大セット数: {workoutConfig.maxSets}
@@ -239,7 +247,7 @@ const WorkoutCustomizationDrawer = ({
                   { value: 2, label: '2' },
                   { value: 3, label: '3' },
                   { value: 4, label: '4' },
-                  { value: 5, label: '5' }
+                  { value: 5, label: '5' },
                 ]}
                 valueLabelDisplay="auto"
                 sx={{ mb: 2 }}
@@ -265,7 +273,7 @@ const WorkoutCustomizationDrawer = ({
                 種目追加
               </Typography>
               <List dense sx={{ maxHeight: 200, overflow: 'auto' }}>
-                {availableToAdd.map((exercise) => (
+                {availableToAdd.map(exercise => (
                   <ListItem key={exercise} divider>
                     <Box sx={{ display: 'flex', alignItems: 'center', mr: 1 }}>
                       {isCardioExercise(exercise) ? (
@@ -274,13 +282,15 @@ const WorkoutCustomizationDrawer = ({
                         <FitnessCenterIcon color="primary" fontSize="small" />
                       )}
                     </Box>
-                    <ListItemText 
+                    <ListItemText
                       primary={exercise}
-                      secondary={isCardioExercise(exercise) ? 'カーディオ' : '筋トレ'}
+                      secondary={
+                        isCardioExercise(exercise) ? 'カーディオ' : '筋トレ'
+                      }
                     />
                     <ListItemSecondaryAction>
-                      <IconButton 
-                        edge="end" 
+                      <IconButton
+                        edge="end"
                         size="small"
                         onClick={() => addExercise(exercise)}
                         color="primary"
@@ -296,18 +306,15 @@ const WorkoutCustomizationDrawer = ({
         </Box>
 
         {/* フッター */}
-        <Box sx={{ 
-          p: 2, 
-          borderTop: '1px solid', 
-          borderColor: 'divider',
-          bgcolor: 'background.paper'
-        }}>
-          <Button 
-            variant="contained" 
-            fullWidth 
-            onClick={onClose}
-            size="large"
-          >
+        <Box
+          sx={{
+            p: 2,
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Button variant="contained" fullWidth onClick={onClose} size="large">
             設定を適用
           </Button>
         </Box>

--- a/frontend/src/components/WorkoutForm.jsx
+++ b/frontend/src/components/WorkoutForm.jsx
@@ -1,76 +1,81 @@
 import { useEffect, useState } from 'react';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 
-
 import { yupResolver } from '@hookform/resolvers/yup';
-import {
-  MenuItem,
-  TextField
-} from '@mui/material';
+import { MenuItem, TextField } from '@mui/material';
 import axios from 'axios';
 import * as yup from 'yup';
 import '../styles/WorkoutForm.css';
 
 const WORKOUT_TYPES = {
   CARDIO: 'cardio',
-  STRENGTH: 'strength'
+  STRENGTH: 'strength',
 };
 
 const workoutExercises = [
   {
     name: 'ウォーキング',
     type: WORKOUT_TYPES.CARDIO,
-    description: '全身運動。心肺機能を高め、脚部の筋肉と体幹を軽く鍛える有酸素運動。20-30分、週3-5回行うのが効果的。メリット：基礎代謝アップ、ストレス軽減、生活習慣病予防、睡眠の質向上、長時間の運動耐性向上',
-    beginner: true
+    description:
+      '全身運動。心肺機能を高め、脚部の筋肉と体幹を軽く鍛える有酸素運動。20-30分、週3-5回行うのが効果的。メリット：基礎代謝アップ、ストレス軽減、生活習慣病予防、睡眠の質向上、長時間の運動耐性向上',
+    beginner: true,
   },
   {
     name: 'ジョギング',
     type: WORKOUT_TYPES.CARDIO,
-    description: '全身運動。心肺機能を向上させ、下半身の筋肉を強化する有酸素運動。15-20分、週2-3回から始めるのが適切。メリット：脂肪燃焼効果が高い、心肺機能の大幅な向上、持久力アップ、メンタルヘルス改善、骨密度増加',
-    beginner: true
+    description:
+      '全身運動。心肺機能を向上させ、下半身の筋肉を強化する有酸素運動。15-20分、週2-3回から始めるのが適切。メリット：脂肪燃焼効果が高い、心肺機能の大幅な向上、持久力アップ、メンタルヘルス改善、骨密度増加',
+    beginner: true,
   },
   {
     name: 'スクワット',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '下半身トレーニング。太もも前部、お尻、体幹を鍛える基本的な自重運動。初めは自重から始め、フォームを重視する。メリット：基礎代謝向上、日常動作の安定性向上、姿勢改善、下半身のバランス強化、ホルモン分泌促進',
-    beginner: true
+    description:
+      '下半身トレーニング。太もも前部、お尻、体幹を鍛える基本的な自重運動。初めは自重から始め、フォームを重視する。メリット：基礎代謝向上、日常動作の安定性向上、姿勢改善、下半身のバランス強化、ホルモン分泌促進',
+    beginner: true,
   },
   {
     name: 'プッシュアップ',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的な自重トレーニング。初心者は膝をついた状態から始めても良い。メリット：上半身の筋力バランス向上、姿勢改善、腕の引き締め効果、体幹強化、どこでも手軽にできる',
-    beginner: true
+    description:
+      '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的な自重トレーニング。初心者は膝をついた状態から始めても良い。メリット：上半身の筋力バランス向上、姿勢改善、腕の引き締め効果、体幹強化、どこでも手軽にできる',
+    beginner: true,
   },
   {
     name: 'ベンチプレス',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的なウェイトトレーニング。初めは軽いバーから始めてフォームを習得する。メリット：上半身の筋肉量増加、押す動作の強化、胸部の発達による姿勢改善、上半身の見た目の向上',
-    beginner: true
+    description:
+      '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的なウェイトトレーニング。初めは軽いバーから始めてフォームを習得する。メリット：上半身の筋肉量増加、押す動作の強化、胸部の発達による姿勢改善、上半身の見た目の向上',
+    beginner: true,
   },
   {
     name: '懸垂（チンニング）',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '上半身トレーニング。広背筋、僧帽筋、上腕二頭筋を中心に鍛える複合運動。自重を使った引く動作のトレーニングで、初心者は補助器具から始めるのがおすすめ。メリット：背中の筋肉の発達、腕力の向上、姿勢改善、グリップ力の強化、体幹の安定性向上',
-    beginner: false
+    description:
+      '上半身トレーニング。広背筋、僧帽筋、上腕二頭筋を中心に鍛える複合運動。自重を使った引く動作のトレーニングで、初心者は補助器具から始めるのがおすすめ。メリット：背中の筋肉の発達、腕力の向上、姿勢改善、グリップ力の強化、体幹の安定性向上',
+    beginner: false,
   },
   {
     name: 'デッドリフト',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '全身トレーニング。背中、お尻、ハムストリングスなど多くの筋群を同時に鍛える複合運動。フォームを重視し、軽い重量から始める。メリット：全身の筋力バランス向上、背筋強化による姿勢改善、基礎代謝の大幅アップ、日常生活での腰痛リスク軽減',
-    beginner: true
+    description:
+      '全身トレーニング。背中、お尻、ハムストリングスなど多くの筋群を同時に鍛える複合運動。フォームを重視し、軽い重量から始める。メリット：全身の筋力バランス向上、背筋強化による姿勢改善、基礎代謝の大幅アップ、日常生活での腰痛リスク軽減',
+    beginner: true,
   },
   {
     name: 'クランチ',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '腹筋運動。主に腹直筋上部を鍛える自重トレーニング。背中への負担が少なく初心者に適している。メリット：体幹安定性の向上、腹部の引き締め効果、姿勢改善、腰痛予防、見た目の変化が実感しやすい',
-    beginner: true
+    description:
+      '腹筋運動。主に腹直筋上部を鍛える自重トレーニング。背中への負担が少なく初心者に適している。メリット：体幹安定性の向上、腹部の引き締め効果、姿勢改善、腰痛予防、見た目の変化が実感しやすい',
+    beginner: true,
   },
   {
     name: 'レッグレイズ',
     type: WORKOUT_TYPES.STRENGTH,
-    description: '腹筋運動。下腹部と腸腰筋を重点的に鍛える自重トレーニング。仰向けに寝た状態から脚を持ち上げる動作で行う。メリット：下腹部の引き締め、体幹強化、姿勢改善、腰痛予防、骨盤の安定性向上',
-    beginner: true
-  }
+    description:
+      '腹筋運動。下腹部と腸腰筋を重点的に鍛える自重トレーニング。仰向けに寝た状態から脚を持ち上げる動作で行う。メリット：下腹部の引き締め、体幹強化、姿勢改善、腰痛予防、骨盤の安定性向上',
+    beginner: true,
+  },
 ];
 
 const SETS_OPTIONS = [1, 2, 3, 4, 5];
@@ -82,30 +87,30 @@ const schema = yup.object().shape({
   exercise: yup.string().required('種目を入力してください'),
   intensity: yup.string().required('強度を選択してください'),
   setNumber: yup.number().when('exercise', {
-    is: (exercise) => getExerciseType(exercise) === WORKOUT_TYPES.STRENGTH,
-    then: yup.number().required('セット数を選択してください')
+    is: exercise => getExerciseType(exercise) === WORKOUT_TYPES.STRENGTH,
+    then: yup.number().required('セット数を選択してください'),
   }),
   repsNumber: yup.array().when('exercise', {
-    is: (exercise) => getExerciseType(exercise) === WORKOUT_TYPES.STRENGTH,
+    is: exercise => getExerciseType(exercise) === WORKOUT_TYPES.STRENGTH,
     then: yup.array().of(
       yup.object().shape({
-        reps: yup.number().required('回数を選択してください')
+        reps: yup.number().required('回数を選択してください'),
       })
-    )
+    ),
   }),
   duration: yup.number().when('exercise', {
-    is: (exercise) => getExerciseType(exercise) === WORKOUT_TYPES.CARDIO,
-    then: yup.number().required('時間を選択してください')
+    is: exercise => getExerciseType(exercise) === WORKOUT_TYPES.CARDIO,
+    then: yup.number().required('時間を選択してください'),
   }),
   distance: yup.number().when('exercise', {
-    is: (exercise) => getExerciseType(exercise) === WORKOUT_TYPES.CARDIO,
-    then: yup.number().required('距離を選択してください')
-  })
+    is: exercise => getExerciseType(exercise) === WORKOUT_TYPES.CARDIO,
+    then: yup.number().required('距離を選択してください'),
+  }),
 });
 
-const getExerciseType = (exerciseName) => {
-  const selectedExercise = workoutExercises.find(exercise =>
-    exercise.name === exerciseName
+const getExerciseType = exerciseName => {
+  const selectedExercise = workoutExercises.find(
+    exercise => exercise.name === exerciseName
   );
   return selectedExercise ? selectedExercise.type : 'null';
 };
@@ -114,7 +119,7 @@ const WorkoutForm = () => {
   const [feedback, setFeedback] = useState({
     message: '',
     type: '',
-    visible: false
+    visible: false,
   });
 
   const {
@@ -131,18 +136,18 @@ const WorkoutForm = () => {
       repsNumber: [
         { id: '1', reps: '' },
         { id: '2', reps: '' },
-        { id: '3', reps: '' }
+        { id: '3', reps: '' },
       ],
       duration: '',
-      intensity: ''
-    }
+      intensity: '',
+    },
   });
 
   const showFeedback = (message, type) => {
     setFeedback({
       message,
       type,
-      visible: true
+      visible: true,
     });
   };
 
@@ -152,7 +157,7 @@ const WorkoutForm = () => {
 
   const { fields, append, remove } = useFieldArray({
     control,
-    name: 'repsNumber'
+    name: 'repsNumber',
   });
   const setNumber = watch('setNumber');
 
@@ -183,12 +188,12 @@ const WorkoutForm = () => {
     }
   }, [feedback.visible]);
 
-  const onSubmit = (data) => {
+  const onSubmit = data => {
     const token = localStorage.getItem('token');
     const config = {
       headers: {
-        Authorization: `Bearer ${token}`
-      }
+        Authorization: `Bearer ${token}`,
+      },
     };
     const exerciseType = getExerciseType(data.exercise);
 
@@ -199,40 +204,42 @@ const WorkoutForm = () => {
         setNumber: parseInt(data.setNumber, 10),
         repsNumber: data.repsNumber.map(rep => ({
           ...rep,
-          reps: parseInt(rep.reps, 10)
-        }))
+          reps: parseInt(rep.reps, 10),
+        })),
       }),
       ...(exerciseType === 'cardio' && {
         distance: parseInt(data.distance, 10),
-        duration: parseInt(data.duration, 10)
-      })
+        duration: parseInt(data.duration, 10),
+      }),
     };
 
-
-    axios.post("http://localhost:8000/workouts", submitData, config)
-      .then((response) => {
-        showFeedback(response.data.message || 'ワークアウトが保存されました', 'success');
+    axios
+      .post('http://localhost:8000/workouts', submitData, config)
+      .then(response => {
+        showFeedback(
+          response.data.message || 'ワークアウトが保存されました',
+          'success'
+        );
         reset();
       })
       .catch(error => {
         console.error('エラー発生:', error.response?.data || error.message);
-        const errorMessage = error.response?.data?.error || 'エラーが発生しました';
+        const errorMessage =
+          error.response?.data?.error || 'エラーが発生しました';
         showFeedback(errorMessage, 'error');
       });
   };
 
-
   return (
-    <form className='formContainer' onSubmit={handleSubmit(onSubmit)}>
-
-      <div className='exercise'>
+    <form className="formContainer" onSubmit={handleSubmit(onSubmit)}>
+      <div className="exercise">
         <Controller
-          name='exercise'
+          name="exercise"
           control={control}
           render={({ field }) => (
             <TextField
               {...field}
-              label='トレーニング名'
+              label="トレーニング名"
               required
               select
               fullWidth
@@ -251,14 +258,14 @@ const WorkoutForm = () => {
 
       {exerciseType === WORKOUT_TYPES.STRENGTH && (
         <>
-          <div className='setNumber'>
+          <div className="setNumber">
             <Controller
-              name='setNumber'
+              name="setNumber"
               control={control}
               render={({ field }) => (
                 <TextField
                   {...field}
-                  label='セット数'
+                  label="セット数"
                   required
                   select
                   fullWidth
@@ -276,7 +283,7 @@ const WorkoutForm = () => {
           </div>
 
           {fields.map((field, index) => (
-            <div key={field.id} className='repsNumber'>
+            <div key={field.id} className="repsNumber">
               <Controller
                 name={`repsNumber.${index}.reps`}
                 control={control}
@@ -300,20 +307,19 @@ const WorkoutForm = () => {
               />
             </div>
           ))}
-
         </>
       )}
 
       {exerciseType === WORKOUT_TYPES.CARDIO && (
         <>
-          <div className='distance'>
+          <div className="distance">
             <Controller
-              name='distance'
+              name="distance"
               control={control}
               render={({ field }) => (
                 <TextField
                   {...field}
-                  label='距離'
+                  label="距離"
                   required
                   select
                   fullWidth
@@ -328,20 +334,13 @@ const WorkoutForm = () => {
                 </TextField>
               )}
             />
-
           </div>
-          <div className='duration'>
+          <div className="duration">
             <Controller
-              name='duration'
+              name="duration"
               control={control}
               render={({ field }) => (
-                <TextField
-                  {...field}
-                  label='時間'
-                  required
-                  select
-                  fullWidth
-                >
+                <TextField {...field} label="時間" required select fullWidth>
                   {DURATION_OPTIONS.map(duration => (
                     <MenuItem key={duration} value={duration}>
                       {duration}
@@ -351,27 +350,21 @@ const WorkoutForm = () => {
               )}
             />
           </div>
-
         </>
       )}
 
-      <div className='intensity'>
+      <div className="intensity">
         <Controller
-          name='intensity'
+          name="intensity"
           control={control}
           render={({ field }) => (
-            <TextField
-              {...field}
-              label='強度'
-              required
-              select
-              fullWidth
-            >
+            <TextField {...field} label="強度" required select fullWidth>
               <MenuItem value="低">楽に感じる（軽い息切れ程度）</MenuItem>
-              <MenuItem value="中">少しきつい（会話しながらできる程度）</MenuItem>
+              <MenuItem value="中">
+                少しきつい（会話しながらできる程度）
+              </MenuItem>
               <MenuItem value="高">かなりきつい（会話が難しい程度）</MenuItem>
             </TextField>
-
           )}
           error={!!errors.intensity}
           helperText={errors.intensity?.message}
@@ -379,17 +372,13 @@ const WorkoutForm = () => {
       </div>
 
       <div>
-        <button type='submit'>送信</button>
+        <button type="submit">送信</button>
       </div>
       {feedback.visible && (
-        <div className={`feedback ${feedback.type}`}>
-          {feedback.message}
-        </div>
+        <div className={`feedback ${feedback.type}`}>{feedback.message}</div>
       )}
-
     </form>
-  )
-}
+  );
+};
 
-
-export default WorkoutForm
+export default WorkoutForm;

--- a/frontend/src/components/WorkoutHistoryTable.jsx
+++ b/frontend/src/components/WorkoutHistoryTable.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
 const WorkoutHistoryTable = ({
-  workouts =[],
+  workouts = [],
   workoutConfig,
   loading = false,
   isCardioExercise,
   isStrengthExercise,
 }) => {
-  
-  if(loading){
+  if (loading) {
     return (
-            <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
+      <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900">詳細履歴</h2>
         </div>
+
         <div className="flex items-center justify-center h-64">
           <div className="animate-spin h-8 w-8 border-4 border-blue-600 border-t-transparent rounded-full"></div>
           <span className="ml-3 text-gray-600">読み込み中...</span>
@@ -22,21 +22,28 @@ const WorkoutHistoryTable = ({
     );
   }
 
-    if (workouts.length === 0) {
+  if (workouts.length === 0) {
     return (
       <div className="bg-blue-50 border border-blue-200 rounded-md p-6 text-center">
         <div className="h-12 w-12 text-blue-400 mx-auto mb-4">📅</div>
-        <p className="text-blue-600 font-medium mb-2">ワークアウト履歴がありません</p>
-        <p className="text-blue-500 text-sm">新しいワークアウトを開始しましょう！</p>
+        <p className="text-blue-600 font-medium mb-2">
+          ワークアウト履歴がありません
+        </p>
+        <p className="text-blue-500 text-sm">
+          新しいワークアウトを開始しましょう！
+        </p>
       </div>
     );
   }
 
-   const getDisplayDescription = () => {
-    console.log(workoutConfig);
-    const cardioExercises = workoutConfig.exercises.filter(ex => isCardioExercise(ex));
-    const strengthExercises = workoutConfig.exercises.filter(ex => isStrengthExercise(ex));
-    
+  const getDisplayDescription = () => {
+    const cardioExercises = workoutConfig.exercises.filter(ex =>
+      isCardioExercise(ex)
+    );
+    const strengthExercises = workoutConfig.exercises.filter(ex =>
+      isStrengthExercise(ex)
+    );
+
     let description = '表示中: ';
     if (cardioExercises.length > 0) {
       description += cardioExercises.join('、') + ' (距離・時間)';
@@ -45,139 +52,159 @@ const WorkoutHistoryTable = ({
       }
     }
     if (strengthExercises.length > 0) {
-      description += strengthExercises.join('、') + ` (${workoutConfig.maxSets}セット)`;
+      description +=
+        strengthExercises.join('、') + ` (${workoutConfig.maxSets}セット)`;
     }
-    
+
     return description;
   };
 
-console.log('=== DETAILED Props Flow Test ===');
-console.log('1. workouts:', workouts);
-console.log('2. workoutConfig:', workoutConfig);
-console.log('3. workoutConfig type:', typeof workoutConfig);
-console.log('4. workoutConfig exercises:', workoutConfig?.exercises);
-console.log('5. loading:', loading);
-console.log('6. isCardioExercise:', isCardioExercise);
-console.log('7. isCardioExercise type:', typeof isCardioExercise);
-
-// 関数動作テスト
-if (isCardioExercise) {
-  console.log('8. isCardioExercise("ランニング"):', isCardioExercise("ランニング"));
-  console.log('9. isCardioExercise("プッシュアップ"):', isCardioExercise("プッシュアップ"));
-}
-
-if (workoutConfig?.exercises) {
-  console.log('10. workoutConfig.exercises:', workoutConfig.exercises);
-  console.log('11. maxSets:', workoutConfig.maxSets);
-  console.log('12. displayColumns:', workoutConfig.displayColumns);
-}
+  console.log('💪🏃‍♀️WorkoutHistoryTable - workouts:', workouts);
+  console.log('💪🏃‍♀️WorkoutHistoryTable - workoutConfig:', workoutConfig);
 
   return (
     <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
       <div className="px-6 py-4 border-b border-gray-200">
         <h2 className="text-lg font-semibold text-gray-900">詳細履歴</h2>
-        <p className="text-sm text-gray-600 mt-1">
-          {getDisplayDescription()}
-        </p>
+        <p className="text-sm text-gray-600 mt-1">{getDisplayDescription()}</p>
       </div>
 
-    <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200">
-        {/* 第1段階: 種目名のヘッダー */}
-        <thead className="bg-gray-50">
-          <tr>
-            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-r border-gray-200">
-              日付
-            </th>
-            {workoutConfig.exercises.map((exerciseName) => {
-              const isCardio = isCardioExercise(exerciseName);
-              const colSpan = isCardio ? 2 : workoutConfig.maxSets;
-              
-              return (
-                <React.Fragment key={exerciseName}>
-                  <th colSpan={colSpan} className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-r border-gray-200">
-                    {exerciseName}
-                    {isCardio && <div className="text-xs text-gray-400 mt-1">(距離・時間)</div>}
-                  </th>
-                </React.Fragment>
-              );
-            })}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
 
-                          {workoutConfig.displayColumns?.includes('totalReps') && (
+          {/* 第1段階: 種目名のヘッダー */}
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-r border-gray-200">
+                日付
+              </th>
+              {workoutConfig.exercises.map(exerciseName => {
+                const isCardio = isCardioExercise(exerciseName);
+                const colSpan = isCardio ? 2 : workoutConfig.maxSets;
+
+                return (
+                  <React.Fragment key={exerciseName}>
+                    <th
+                      colSpan={colSpan}
+                      className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-r border-gray-200"
+                    >
+                      {exerciseName}
+                      {isCardio && (
+                        <div className="text-xs text-gray-400 mt-1">
+                          (距離・時間)
+                        </div>
+                      )}
+                    </th>
+                  </React.Fragment>
+                );
+              })}
+
+              {workoutConfig.displayColumns?.includes('totalReps') && (
                 <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-r border-gray-200">
                   合計回数
                 </th>
               )}
+
               {workoutConfig.displayColumns?.includes('totalTime') && (
                 <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
                   合計時間
                 </th>
               )}
-          </tr>
+            </tr>
 
-          <tr className="bg-gray-100">
-            <th className="px-4 py-2 border-r border-gray-200"></th>
-            {workoutConfig.exercises.map((exerciseName) => {
-              const isCardio = isCardioExercise(exerciseName);
-              
-              return (
-                <React.Fragment key={`${exerciseName}-headers`}>
-                  {isCardio ? (
-                    <>
-                      <th className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200">距離(km)</th>
-                      <th className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200">時間(分)</th>
-                    </>
-                  ) : (
-                    Array.from({ length: workoutConfig.maxSets }, (_, i) => (
-                      <th key={i} className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200">
-                        {i + 1}セット
-                      </th>
-                    ))
-                  )}
-                </React.Fragment>
-              );
-            })}
-                          {workoutConfig.displayColumns?.includes('totalReps') && (
+            <tr className="bg-gray-100">
+              <th className="px-4 py-2 border-r border-gray-200"></th>
+              {workoutConfig.exercises.map(exerciseName => {
+                const isCardio = isCardioExercise(exerciseName);
+
+                return (
+                  <React.Fragment key={`${exerciseName}-headers`}>
+                    {isCardio ? (
+                      <>
+                        <th className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200">
+                          距離(km)
+                        </th>
+                        <th className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200">
+                          時間(分)
+                        </th>
+                      </>
+                    ) : (
+                      Array.from({ length: workoutConfig.maxSets }, (_, i) => (
+                        <th
+                          key={i}
+                          className="px-3 py-2 text-xs text-gray-600 border-r border-gray-200"
+                        >
+                          {i + 1}セット
+                        </th>
+                      ))
+                    )}
+                  </React.Fragment>
+                );
+              })}
+
+              {workoutConfig.displayColumns?.includes('totalReps') && (
                 <th className="px-4 py-2 border-r border-gray-200"></th>
               )}
               {workoutConfig.displayColumns?.includes('totalTime') && (
                 <th className="px-4 py-2"></th>
               )}
-          </tr>
-        </thead>
+            </tr>
+          </thead>
 
-        <tbody>
-          {workoutConfig.exercises.map((exerciseName) => {
-            const exercise = workoutConfig.exercises[exerciseName];
-            const isCardio = isCardioExercise(exerciseName);
-
-            return (
-              <React.Fragment key={exerciseName}>
-                {isCardio ? (
-                  <>
-                    <td className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
-                      {exercise?.distance ? `${exercise.distance}km` : '-'}
-                    </td>
-                    <td className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
-                      {exercise?.duration ? `${exercise.duration}分` : '-'}
-                    </td>
-                  </>
-                ) : (
-                  Array.from({ length: workoutConfig.maxSets }, (_, i) => {
-                    const setKey = `set${i + 1}`;
-                    return (
-                      <td key={setKey} className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
-                        {exercise?.[setKey] || '-'}
-                      </td>
-                    );
-                  })
-                )}
-              </React.Fragment>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+<tbody className="bg-white divide-y divide-gray-200">
+  {workouts.map((workout, index) => (
+    <tr key={workout.date} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+      {/* 日付セル */}
+      <td className="px-4 py-3 text-sm font-medium text-gray-900 border-r border-gray-200">
+        {workout.date}
+      </td>
+      
+      {/* 各種目のデータセル */}
+      {workoutConfig.exercises.map((exerciseName) => {
+        const exercise = workout.exercises[exerciseName]; // ✅ 正しいアクセス
+        const isCardio = isCardioExercise(exerciseName);
+        
+        return (
+          <React.Fragment key={`${workout.date}-${exerciseName}`}>
+            {isCardio ? (
+              <>
+                <td className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
+                  {exercise?.distance ? `${exercise.distance}km` : '-'}
+                </td>
+                <td className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
+                  {exercise?.duration ? `${exercise.duration}分` : '-'}
+                </td>
+              </>
+            ) : (
+              Array.from({ length: workoutConfig.maxSets }, (_, i) => {
+                const setKey = `set${i + 1}`;
+                return (
+                  <td key={setKey} className="px-3 py-3 text-sm text-center text-gray-700 border-r border-gray-200">
+                    {exercise?.[setKey] || '-'}
+                  </td>
+                );
+              })
+            )}
+          </React.Fragment>
+        );
+      })}
+      
+      {/* 合計値セル */}
+      {workoutConfig.displayColumns?.includes('totalReps') && (
+        <td className="px-4 py-3 text-sm text-center font-semibold text-blue-600 border-r border-gray-200">
+          {workout.totalReps}
+        </td>
+      )}
+      {workoutConfig.displayColumns?.includes('totalTime') && (
+        <td className="px-4 py-3 text-sm text-center font-semibold text-purple-600">
+          {workout.totalTime}分
+        </td>
+      )}
+    </tr>
+  ))}
+</tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/forms/FormFields/ExerciseSelect.jsx
+++ b/frontend/src/components/forms/FormFields/ExerciseSelect.jsx
@@ -2,12 +2,12 @@ import { MenuItem, TextField } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import { EXERCISE_OPTIONS } from '../../../config/exercise';
 
-const ExerciseSelect = ({ 
+const ExerciseSelect = ({
   control,
   errors,
   exercises = EXERCISE_OPTIONS,
   label = 'トレーニング種目',
-  name = 'exercise'
+  name = 'exercise',
 }) => {
   // エラーハンドリング: exercisesが無効な場合
   if (!Array.isArray(exercises) || exercises.length === 0) {
@@ -16,7 +16,7 @@ const ExerciseSelect = ({
   }
 
   return (
-    <div className='exercise'>
+    <div className="exercise">
       <Controller
         name={name}
         control={control}
@@ -29,7 +29,7 @@ const ExerciseSelect = ({
             error={!!errors[name]}
             helperText={errors[name]?.message}
           >
-            {exercises.map((exercise) => (
+            {exercises.map(exercise => (
               <MenuItem key={exercise.name} value={exercise.name}>
                 {exercise.name}
               </MenuItem>

--- a/frontend/src/components/forms/FormFields/TargetAmount.jsx
+++ b/frontend/src/components/forms/FormFields/TargetAmount.jsx
@@ -1,15 +1,15 @@
 import { Controller } from 'react-hook-form';
 import { TextField } from '@mui/material';
 
-const TargetAmount = ({ 
+const TargetAmount = ({
   control,
   errors,
   label = '目標回数',
   name = 'targetAmount',
-  type = 'number'
+  type = 'number',
 }) => {
   return (
-    <div className='targetAmount'>
+    <div className="targetAmount">
       <Controller
         name={name}
         control={control}
@@ -28,4 +28,4 @@ const TargetAmount = ({
   );
 };
 
-export default TargetAmount
+export default TargetAmount;

--- a/frontend/src/components/statistics/StatCard.jsx
+++ b/frontend/src/components/statistics/StatCard.jsx
@@ -1,8 +1,8 @@
-import { 
-  Grid, 
-  Card, 
-  CardContent, 
-  Typography, 
+import {
+  Grid,
+  Card,
+  CardContent,
+  Typography,
   Box,
   Avatar,
   Chip,
@@ -12,68 +12,71 @@ import {
   TrendingDown as TrendingDownIcon,
 } from '@mui/icons-material';
 
-const StatCard = ({ 
+const StatCard = ({
   title,
-   value, 
-   unit,
-   changeRate,
-   icon: Icon, 
-   lastValue,
-   color }) => {
-      const isPositive = changeRate >= 0;
-      const TrendIcon = isPositive ? TrendingUpIcon : TrendingDownIcon;
+  value,
+  unit,
+  changeRate,
+  icon: Icon,
+  lastValue,
+  color,
+}) => {
+  const isPositive = changeRate >= 0;
+  const TrendIcon = isPositive ? TrendingUpIcon : TrendingDownIcon;
 
-      return (
-        <Grid item xs={12} sm={6} md={4}>
-        <Card
+  return (
+    <Grid item xs={12} sm={6} md={4}>
+      <Card
         elevation={2}
-        sx={{ 
+        sx={{
           height: '100%',
           transition: 'transform 0.2s ease-in-out',
           '&:hover': {
             transform: 'translateY(-4px)',
-            boxShadow: 3
-          }
+            boxShadow: 3,
+          },
         }}
-        >
-          <CardContent>
-            <Box display="flex" alignItems="center" mb={2}>
-                          <Avatar 
-              sx={{ 
-                bgcolor: `${color}.main`, 
+      >
+        <CardContent>
+          <Box display="flex" alignItems="center" mb={2}>
+            <Avatar
+              sx={{
+                bgcolor: `${color}.main`,
                 mr: 2,
                 width: 48,
-                height: 48
+                height: 48,
               }}
             >
               <Icon />
             </Avatar>
-                        <Box flex={1}>
-              <Typography 
-                variant="h4" 
-                component="div" 
+            <Box flex={1}>
+              <Typography
+                variant="h4"
+                component="div"
                 fontWeight="bold"
                 color="text.primary"
               >
-                {value}{unit}
+                {value}
+                {unit}
               </Typography>
-              <Typography 
-                variant="body2" 
+              <Typography
+                variant="body2"
                 color="text.secondary"
                 sx={{ mt: 0.5 }}
               >
                 {title}
               </Typography>
             </Box>
-            </Box>
+          </Box>
 
-            <Box 
-            display="flex" 
-            justifyContent="space-between" 
+          <Box
+            display="flex"
+            justifyContent="space-between"
             alignItems="center"
           >
             <Typography variant="caption" color="text.secondary">
-              先月 {lastValue}{unit}
+              先月 {lastValue}
+              {unit}
             </Typography>
             <Chip
               icon={<TrendIcon />}
@@ -83,10 +86,9 @@ const StatCard = ({
               variant="outlined"
             />
           </Box>
-
-          </CardContent>
-        </Card>
-        </Grid>
-      )
-}
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+};
 export default StatCard;

--- a/frontend/src/components/statistics/StatisticsLoading.jsx
+++ b/frontend/src/components/statistics/StatisticsLoading.jsx
@@ -1,50 +1,39 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  Grid,
-  Skeleton
-} from '@mui/material';
+import { Box, Card, CardContent, Grid, Skeleton } from '@mui/material';
 
 const StatisticsLoading = () => {
-    return (
-        <Grid container spacing={3} sx={{ mb: 4 }}>
-        {[1, 2, 3].map((i) => (
-               <Grid item xs={12} md={4} key={i}>
-        <Card elevation={2}>
-          <CardContent>
-                        <Box display="flex" alignItems="center" mb={2}>
-              <Skeleton 
-                variant="circular" 
-                width={48} 
-                height={48} 
-                sx={{ mr: 2 }} 
-              />
-          <Box flex={1}>
-                <Skeleton 
-                  variant="text" 
-                  width="60%" 
-                  height={40}
-                  sx={{ mb: 1 }}
+  return (
+    <Grid container spacing={3} sx={{ mb: 4 }}>
+      {[1, 2, 3].map(i => (
+        <Grid item xs={12} md={4} key={i}>
+          <Card elevation={2}>
+            <CardContent>
+              <Box display="flex" alignItems="center" mb={2}>
+                <Skeleton
+                  variant="circular"
+                  width={48}
+                  height={48}
+                  sx={{ mr: 2 }}
                 />
-                                <Skeleton 
-                  variant="text" 
-                  width="80%" 
-                  height={20}
-                />
+                <Box flex={1}>
+                  <Skeleton
+                    variant="text"
+                    width="60%"
+                    height={40}
+                    sx={{ mb: 1 }}
+                  />
+                  <Skeleton variant="text" width="80%" height={20} />
+                </Box>
               </Box>
-                          </Box>
-            <Box display="flex" justifyContent="space-between">
-              <Skeleton variant="text" width="40%" />
-              <Skeleton variant="rounded" width={60} height={24} />
-            </Box>
-          </CardContent>
-        </Card>
-      </Grid>
-        ))}
-      </Grid>
-    )
-
-}
+              <Box display="flex" justifyContent="space-between">
+                <Skeleton variant="text" width="40%" />
+                <Skeleton variant="rounded" width={60} height={24} />
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
 
 export default StatisticsLoading;

--- a/frontend/src/components/statistics/WorkoutStatistics.jsx
+++ b/frontend/src/components/statistics/WorkoutStatistics.jsx
@@ -1,20 +1,17 @@
 import calculateWorkoutStats from '../../services/StatisticsService';
 import StatCard from './StatCard';
 import StatisticsLoading from './StatisticsLoading';
-import { 
-  Grid, 
-} from '@mui/material';
+import { Grid } from '@mui/material';
 
 import {
   CalendarToday as CalendarIcon,
   FitnessCenter as FitnessIcon,
-  Timer as TimerIcon
+  Timer as TimerIcon,
 } from '@mui/icons-material';
 
 const WorkoutStatistics = ({ workouts, loading }) => {
-
   const stats = calculateWorkoutStats(workouts);
-  
+
   if (loading) {
     return <StatisticsLoading />;
   }

--- a/frontend/src/config/exercise.js
+++ b/frontend/src/config/exercise.js
@@ -1,6 +1,6 @@
 export const WORKOUT_TYPES = {
   CARDIO: 'strength',
-  STRENGTH: 'strength'
+  STRENGTH: 'strength',
 };
 
 export const EXERCISE_OPTIONS = [
@@ -12,10 +12,9 @@ export const EXERCISE_OPTIONS = [
   { name: '懸垂（チンニング）', type: WORKOUT_TYPES.STRENGTH },
   { name: 'デッドリフト', type: WORKOUT_TYPES.STRENGTH },
   { name: 'クランチ', type: WORKOUT_TYPES.STRENGTH },
-  { name: 'レッグレイズ', type: WORKOUT_TYPES.STRENGTH }
+  { name: 'レッグレイズ', type: WORKOUT_TYPES.STRENGTH },
 ];
 
 export const METRIC_UNITS = [
-  { value: 'reps', label: '回', forType: WORKOUT_TYPES.STRENGTH }
+  { value: 'reps', label: '回', forType: WORKOUT_TYPES.STRENGTH },
 ];
-

--- a/frontend/src/config/pageStructure.js
+++ b/frontend/src/config/pageStructure.js
@@ -1,7 +1,7 @@
 const configStructure = {
   exercisesDisplay: [],
   maxExercises: 3,
-  displayColumns: []
+  displayColumns: [],
 };
 
 export default configStructure;

--- a/frontend/src/data/exercises.ts
+++ b/frontend/src/data/exercises.ts
@@ -1,99 +1,109 @@
-
 export const WORKOUT_TYPES = {
   CARDIO: 'cardio',
-  STRENGTH: 'strength'
+  STRENGTH: 'strength',
 } as const;
 
-export type WorkoutType = typeof WORKOUT_TYPES[keyof typeof WORKOUT_TYPES];
+export type WorkoutType = (typeof WORKOUT_TYPES)[keyof typeof WORKOUT_TYPES];
 
 export const EXERCISE_DATABASE = {
   walking: {
     id: 'walking',
     name: 'ウォーキング',
     type: 'cardio' as const,
-    description: '全身運動。心肺機能を高め、脚部の筋肉と体幹を軽く鍛える有酸素運動。20-30分、週3-5回行うのが効果的。',
+    description:
+      '全身運動。心肺機能を高め、脚部の筋肉と体幹を軽く鍛える有酸素運動。20-30分、週3-5回行うのが効果的。',
     beginner: true,
-    metrics: ['duration', 'distance'] as const
+    metrics: ['duration', 'distance'] as const,
   },
   jogging: {
     id: 'jogging',
     name: 'ジョギング',
     type: 'cardio' as const,
-    description: '全身運動。心肺機能を向上させ、下半身の筋肉を強化する有酸素運動。15-20分、週2-3回から始めるのが適切。',
+    description:
+      '全身運動。心肺機能を向上させ、下半身の筋肉を強化する有酸素運動。15-20分、週2-3回から始めるのが適切。',
     beginner: true,
-    metrics: ['duration', 'distance'] as const
+    metrics: ['duration', 'distance'] as const,
   },
-    running: {
+  running: {
     id: 'running',
     name: 'ランニング',
     type: 'cardio' as const,
-    description: '高強度の有酸素運動。心肺機能を大幅に向上させ、下半身の筋力強化にも効果的。',
+    description:
+      '高強度の有酸素運動。心肺機能を大幅に向上させ、下半身の筋力強化にも効果的。',
     beginner: true,
-    metrics: ['duration', 'distance'] as const
+    metrics: ['duration', 'distance'] as const,
   },
   cycling: {
     id: 'cycling',
     name: 'サイクリング',
     type: 'cardio' as const,
-    description: '低負荷で持続可能な有酸素運動。膝への負担が少なく、下半身強化に効果的。',
+    description:
+      '低負荷で持続可能な有酸素運動。膝への負担が少なく、下半身強化に効果的。',
     beginner: true,
-    metrics: ['duration', 'distance'] as const
+    metrics: ['duration', 'distance'] as const,
   },
   squat: {
     id: 'squat',
     name: 'スクワット',
     type: 'strength' as const,
-    description: '下半身トレーニング。太もも前部、お尻、体幹を鍛える基本的な自重運動。',
+    description:
+      '下半身トレーニング。太もも前部、お尻、体幹を鍛える基本的な自重運動。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
   pushup: {
     id: 'pushup',
     name: 'プッシュアップ',
     type: 'strength' as const,
-    description: '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的な自重トレーニング。',
+    description:
+      '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的な自重トレーニング。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
-    plank: {
+  plank: {
     id: 'plank',
     name: 'プランク',
     type: 'strength' as const,
-    description: '体幹トレーニング。腹筋、背筋、インナーマッスルを同時に鍛える静的運動。',
+    description:
+      '体幹トレーニング。腹筋、背筋、インナーマッスルを同時に鍛える静的運動。',
     beginner: true,
-    metrics: ['duration'] as const
+    metrics: ['duration'] as const,
   },
   benchpress: {
     id: 'benchpress',
     name: 'ベンチプレス',
     type: 'strength' as const,
-    description: '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的なウェイトトレーニング。',
+    description:
+      '上半身トレーニング。胸筋、三頭筋、肩を鍛える基本的なウェイトトレーニング。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
-    diamond_pushup: {
+  diamond_pushup: {
     id: 'diamond_pushup',
     name: 'ダイヤモンドプッシュアップ',
     type: 'strength' as const,
-    description: '上腕三頭筋に特化したプッシュアップバリエーション。胸筋下部も鍛える。',
+    description:
+      '上腕三頭筋に特化したプッシュアップバリエーション。胸筋下部も鍛える。',
     beginner: false,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
   pullup: {
     id: 'pullup',
     name: '懸垂（チンニング）',
     type: 'strength' as const,
-    description: '上半身トレーニング。広背筋、僧帽筋、上腕二頭筋を中心に鍛える複合運動。',
+    description:
+      '上半身トレーニング。広背筋、僧帽筋、上腕二頭筋を中心に鍛える複合運動。',
     beginner: false,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
   deadlift: {
     id: 'deadlift',
     name: 'デッドリフト',
     type: 'strength' as const,
-    description: '全身トレーニング。背中、お尻、ハムストリングスなど多くの筋群を同時に鍛える複合運動。',
+    description:
+      '全身トレーニング。背中、お尻、ハムストリングスなど多くの筋群を同時に鍛える複合運動。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
   crunch: {
     id: 'crunch',
@@ -101,7 +111,7 @@ export const EXERCISE_DATABASE = {
     type: 'strength' as const,
     description: '腹筋運動。主に腹直筋上部を鍛える自重トレーニング。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
+    metrics: ['sets', 'reps'] as const,
   },
   legraise: {
     id: 'legraise',
@@ -109,12 +119,11 @@ export const EXERCISE_DATABASE = {
     type: 'strength' as const,
     description: '腹筋運動。下腹部と腸腰筋を重点的に鍛える自重トレーニング。',
     beginner: true,
-    metrics: ['sets', 'reps'] as const
-  }
+    metrics: ['sets', 'reps'] as const,
+  },
 } as const;
 
 export const EXERCISE_OPTIONS = Object.values(EXERCISE_DATABASE);
 
 export type ExerciseId = keyof typeof EXERCISE_DATABASE;
-export type Exercise = typeof EXERCISE_DATABASE[ExerciseId];
-
+export type Exercise = (typeof EXERCISE_DATABASE)[ExerciseId];

--- a/frontend/src/hooks/useFeedback.ts
+++ b/frontend/src/hooks/useFeedback.ts
@@ -22,6 +22,6 @@ export const useFeedback = () => {
   return {
     feedback,
     showFeedback,
-    hideFeedback
+    hideFeedback,
   };
 };

--- a/frontend/src/hooks/useWorkoutConfig.js
+++ b/frontend/src/hooks/useWorkoutConfig.js
@@ -6,101 +6,121 @@ const useWorkoutConfig = () => {
     const cardio = [];
     const strength = [];
     const nameMapping = {};
-    
+
     Object.values(EXERCISE_DATABASE).forEach(exercise => {
       nameMapping[exercise.id] = exercise.name;
-      
+
       if (exercise.type === WORKOUT_TYPES.CARDIO) {
         cardio.push(exercise.name);
       } else if (exercise.type === WORKOUT_TYPES.STRENGTH) {
         strength.push(exercise.name);
       }
     });
-    
+
     return {
       cardio,
       strength,
       all: [...cardio, ...strength],
       nameMapping,
-      database: EXERCISE_DATABASE
+      database: EXERCISE_DATABASE,
     };
   }, []);
 
-    const [workoutConfig, setWorkoutConfig] = useState({
+  const [workoutConfig, setWorkoutConfig] = useState({
     exercises: [
       exerciseData.nameMapping.pushup || 'プッシュアップ',
-      exerciseData.nameMapping.squat || 'スクワット', 
-      exerciseData.nameMapping.walking || 'ウォーキング'
+      exerciseData.nameMapping.squat || 'スクワット',
+      exerciseData.nameMapping.walking || 'ウォーキング',
     ],
     maxSets: 3,
-    displayColumns: ['totalReps', 'totalTime']
+    displayColumns: ['totalReps', 'totalTime'],
   });
 
-   const isCardioExercise = useCallback((exerciseName) => {
-    return exerciseData.cardio.includes(exerciseName);
-  }, [exerciseData.cardio]);
+  const isCardioExercise = useCallback(
+    exerciseName => {
+      return exerciseData.cardio.includes(exerciseName);
+    },
+    [exerciseData.cardio]
+  );
 
-  const isStrengthExercise = useCallback((exerciseName) => {
-    return exerciseData.strength.includes(exerciseName);
-  }, [exerciseData.strength]);
+  const isStrengthExercise = useCallback(
+    exerciseName => {
+      return exerciseData.strength.includes(exerciseName);
+    },
+    [exerciseData.strength]
+  );
 
-  const getExerciseInfo = useCallback((exerciseName) => {
+  const getExerciseInfo = useCallback(exerciseName => {
     return Object.values(EXERCISE_DATABASE).find(
       exercise => exercise.name === exerciseName
     );
   }, []);
 
-  const presets = useMemo(() => ({
-    strength_basic: {
-      name: '筋トレ基本',
-      exercises: [
-        exerciseData.nameMapping.pushup,
-        exerciseData.nameMapping.squat,
-        exerciseData.nameMapping.crunch
-      ].filter(Boolean), // undefined除外
-      maxSets: 3
-    },
-    cardio_basic: {
-      name: 'カーディオ基本', 
-      exercises: [
-        exerciseData.nameMapping.walking,
-        exerciseData.nameMapping.jogging
-      ].filter(Boolean),
-      maxSets: 1
-    },
-    mixed_beginner: {
-      name: '初心者ミックス',
-      exercises: [
-        exerciseData.nameMapping.walking,
-        exerciseData.nameMapping.pushup,
-        exerciseData.nameMapping.squat
-      ].filter(Boolean),
-      maxSets: 2
-    },
-    advanced_strength: {
-      name: '上級筋トレ',
-      exercises: [
-        exerciseData.nameMapping.deadlift,
-        exerciseData.nameMapping.pullup,
-        exerciseData.nameMapping.benchpress
-      ].filter(Boolean),
-      maxSets: 3
-    }
-  }), [exerciseData.nameMapping]);
+  const updateDisplayColumns = columns => {
+    setWorkoutConfig(prev => ({
+      ...prev,
+      displayColumns: columns,
+    }));
+  };
 
-    useEffect(() => {
+  const presets = useMemo(
+    () => ({
+      strength_basic: {
+        name: '筋トレ基本',
+        exercises: [
+          exerciseData.nameMapping.pushup,
+          exerciseData.nameMapping.squat,
+          exerciseData.nameMapping.crunch,
+        ].filter(Boolean), // undefined除外
+        maxSets: 3,
+      },
+      cardio_basic: {
+        name: 'カーディオ基本',
+        exercises: [
+          exerciseData.nameMapping.walking,
+          exerciseData.nameMapping.jogging,
+        ].filter(Boolean),
+        maxSets: 1,
+      },
+      mixed_beginner: {
+        name: '初心者ミックス',
+        exercises: [
+          exerciseData.nameMapping.walking,
+          exerciseData.nameMapping.pushup,
+          exerciseData.nameMapping.squat,
+        ].filter(Boolean),
+        maxSets: 2,
+      },
+      advanced_strength: {
+        name: '上級筋トレ',
+        exercises: [
+          exerciseData.nameMapping.deadlift,
+          exerciseData.nameMapping.pullup,
+          exerciseData.nameMapping.benchpress,
+        ].filter(Boolean),
+        maxSets: 3,
+      },
+    }),
+    [exerciseData.nameMapping]
+  );
+
+  useEffect(() => {
     const savedConfig = localStorage.getItem('workoutConfig');
     if (savedConfig) {
       try {
         const parsed = JSON.parse(savedConfig);
         // バリデーション：exercises.tsに存在する種目のみ許可
-        const validExercises = parsed.exercises?.filter(exercise => 
-          exerciseData.all.includes(exercise)
-        ) || [];
-        
+        const validExercises =
+          parsed.exercises?.filter(exercise =>
+            exerciseData.all.includes(exercise)
+          ) || [];
+
         setWorkoutConfig({
           ...parsed,
-          exercises: validExercises.length > 0 ? validExercises : workoutConfig.exercises
+          exercises:
+            validExercises.length > 0
+              ? validExercises
+              : workoutConfig.exercises,
         });
         console.log('📖 設定読み込み・バリデーション完了:', parsed);
       } catch (error) {
@@ -109,79 +129,90 @@ const useWorkoutConfig = () => {
     }
   }, [exerciseData.all]);
 
-    const saveConfig = useCallback((newConfig) => {
+  const saveConfig = useCallback(newConfig => {
     setWorkoutConfig(newConfig);
     localStorage.setItem('workoutConfig', JSON.stringify(newConfig));
     console.log('💾 設定保存完了:', newConfig);
   }, []);
 
-    const addExercise = useCallback((exercise) => {
-   if (!exerciseData.all.includes(exercise)) {
-    console.error('❌ 未定義の種目:', exercise);
-    console.log('利用可能な種目:', exerciseData.all);
-    alert(`「${exercise}」は利用できません`);
-    return;
-  }
-    
-    if (workoutConfig.exercises.length >= 3) {
-      alert('種目は最大3つまでです');
-      return;
-    }
-    
-    if (workoutConfig.exercises.includes(exercise)) {
-      alert('すでに選択済みの種目です');
-      return;
-    }
+  const addExercise = useCallback(
+    exercise => {
+      if (!exerciseData.all.includes(exercise)) {
+        console.error('❌ 未定義の種目:', exercise);
+        console.log('利用可能な種目:', exerciseData.all);
+        alert(`「${exercise}」は利用できません`);
+        return;
+      }
 
-    const newConfig = {
-      ...workoutConfig,
-      exercises: [...workoutConfig.exercises, exercise]
-    };
-    saveConfig(newConfig);
-  }, [workoutConfig, saveConfig, exerciseData.all]);
+      if (workoutConfig.exercises.length >= 3) {
+        alert('種目は最大3つまでです');
+        return;
+      }
 
-  const removeExercise = useCallback((exercise) => {
-  if (workoutConfig.exercises.length <= 1) {
-    alert('最低1つの運動は必要です');
-    return;
-  }
-  const newConfig = {
-    ...workoutConfig,
-    exercises: workoutConfig.exercises.filter(ex => ex !== exercise)
-  };
-  saveConfig(newConfig);
-}, [workoutConfig, saveConfig]);
+      if (workoutConfig.exercises.includes(exercise)) {
+        alert('すでに選択済みの種目です');
+        return;
+      }
 
-const applyPreset = useCallback((presetKey) => {
-    const preset = presets[presetKey];
+      const newConfig = {
+        ...workoutConfig,
+        exercises: [...workoutConfig.exercises, exercise],
+      };
+      saveConfig(newConfig);
+    },
+    [workoutConfig, saveConfig, exerciseData.all]
+  );
 
-     if (!preset) {
-    console.error('❌ 存在しないプリセット:', presetKey);
-    console.log('利用可能なプリセット:', Object.keys(presets));
-    return;
-  }
-  
-  if (!preset.exercises || !Array.isArray(preset.exercises)) {
-    console.error('❌ プリセットの運動リストが無効:', preset);
-    return;
-  }
+  const removeExercise = useCallback(
+    exercise => {
+      if (workoutConfig.exercises.length <= 1) {
+        alert('最低1つの運動は必要です');
+        return;
+      }
+      const newConfig = {
+        ...workoutConfig,
+        exercises: workoutConfig.exercises.filter(ex => ex !== exercise),
+      };
+      saveConfig(newConfig);
+    },
+    [workoutConfig, saveConfig]
+  );
 
-    const newConfig = {
-      ...workoutConfig,
-      exercises: preset.exercises,
-      maxSets: preset.maxSets
-    };
-    saveConfig(newConfig);
-  }, [workoutConfig, saveConfig, presets]);
+  const applyPreset = useCallback(
+    presetKey => {
+      const preset = presets[presetKey];
 
-    const updateMaxSets = useCallback((sets) => {
-    const newConfig = {
-      ...workoutConfig,
-      maxSets: sets
-    };
-    saveConfig(newConfig);
-  }, [workoutConfig, saveConfig]);
-  
+      if (!preset) {
+        console.error('❌ 存在しないプリセット:', presetKey);
+        console.log('利用可能なプリセット:', Object.keys(presets));
+        return;
+      }
+
+      if (!preset.exercises || !Array.isArray(preset.exercises)) {
+        console.error('❌ プリセットの運動リストが無効:', preset);
+        return;
+      }
+
+      const newConfig = {
+        ...workoutConfig,
+        exercises: preset.exercises,
+        maxSets: preset.maxSets,
+      };
+      saveConfig(newConfig);
+    },
+    [workoutConfig, saveConfig, presets]
+  );
+
+  const updateMaxSets = useCallback(
+    sets => {
+      const newConfig = {
+        ...workoutConfig,
+        maxSets: sets,
+      };
+      saveConfig(newConfig);
+    },
+    [workoutConfig, saveConfig]
+  );
 
   return {
     // 状態
@@ -193,16 +224,15 @@ const applyPreset = useCallback((presetKey) => {
     // ユーティリティ
     isCardioExercise,
     isStrengthExercise,
-    getExerciseInfo, 
+    getExerciseInfo,
+    updateDisplayColumns,
 
     // アクション関数
     saveConfig,
     addExercise,
     removeExercise,
     applyPreset,
-    updateMaxSets
-
-
+    updateMaxSets,
   };
 };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
-import { StrictMode } from 'react'
-import { createRoot, Root } from 'react-dom/client'
-import App from './App'
+import { StrictMode } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import App from './App';
 
 const rootElement: HTMLElement | null = document.getElementById('root');
 
@@ -14,5 +14,4 @@ root.render(
   <StrictMode>
     <App />
   </StrictMode>
-)
-
+);

--- a/frontend/src/pages/Dashboad.jsx
+++ b/frontend/src/pages/Dashboad.jsx
@@ -1,10 +1,5 @@
-
-
 export const DashboadPage = () => {
-  return (
-    <>
-    </>
-  )
-}
+  return <></>;
+};
 
 export default DashboadPage;

--- a/frontend/src/pages/Logout.jsx
+++ b/frontend/src/pages/Logout.jsx
@@ -1,12 +1,10 @@
-
-
 const Logout = () => {
   return (
     <div>
       <h1>ログアウト</h1>
       <button>ログアウト</button>
     </div>
-  )
-}
+  );
+};
 
-export default Logout
+export default Logout;

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,12 +1,7 @@
-
-import Register from '../components/Register'
-
+import Register from '../components/Register';
 
 const RegisterPage = () => {
-  return (
-
-    <Register />
-  )
-}
+  return <Register />;
+};
 
 export default RegisterPage;

--- a/frontend/src/pages/WorkoutForm.jsx
+++ b/frontend/src/pages/WorkoutForm.jsx
@@ -1,12 +1,11 @@
-import WorkoutForm from "../components/WorkoutForm"
+import WorkoutForm from '../components/WorkoutForm';
 
 const WorkoutFormPage = () => {
   return (
     <div>
       <WorkoutForm />
     </div>
-
-  )
-}
+  );
+};
 
 export default WorkoutFormPage;

--- a/frontend/src/pages/WorkoutHistory.jsx
+++ b/frontend/src/pages/WorkoutHistory.jsx
@@ -1,21 +1,7 @@
 import { Settings as SettingsIcon } from '@mui/icons-material';
-import {
-  Alert,
-  Button,
-  CircularProgress,
-  Collapse,
-  Container,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography
-} from '@mui/material';
+import { Button, Container, Typography } from '@mui/material';
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import WorkoutStatistics from '../components/statistics/WorkoutStatistics';
 import WorkoutCustomizationDrawer from '../components/WorkoutCustomizationDrawer';
 import WorkoutHistoryTable from '../components/WorkoutHistoryTable';
@@ -26,8 +12,7 @@ const WorkoutHistory = () => {
   const [workouts, setWorkouts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [openId, setOpenId] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false); // カスタマイズドロワーの開閉状態
 
   const {
     workoutConfig,
@@ -38,48 +23,41 @@ const WorkoutHistory = () => {
     addExercise,
     removeExercise,
     applyPreset,
-    updateMaxSets
+    updateMaxSets,
   } = useWorkoutConfig();
 
   useEffect(() => {
-    const controller = new AbortController();
     const fetchWorkouts = async () => {
       try {
         setLoading(true);
+        const token = localStorage.getItem('token');
         const response = await axios.get('http://localhost:8000/workouts', {
-          signal: controller.signal
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
         });
         const transformedData = transformWorkoutData(response.data);
-        console.log(transformedData);
+        console.log('📊WorkoutHistory - transformedData:', transformedData);
         setWorkouts(transformedData);
         setLoading(false);
       } catch (error) {
-        if (axios.isCancel(error)) {
-          console.log('ワークアウト履歴の取得がキャンセルされました');
-          return;
-        }
+        console.error('ワークアウト履歴の取得に失敗しました:', error);
         setError(error);
         setLoading(false);
+        setWorkouts([]);
       }
     };
     fetchWorkouts();
-    return () => controller.abort();
   }, []);
-
-
-
-  const toggle = (id) => {
-    setOpenId(openId === id ? null : id);
-  };
 
   const getConfigDescription = () => {
     if (workoutConfig.exercises.length === 0) {
       return '種目が選択されていません';
     }
-    
+
     const cardio = workoutConfig.exercises.filter(isCardioExercise);
     const strength = workoutConfig.exercises.filter(isStrengthExercise);
-    
+
     let description = '';
     if (cardio.length > 0) {
       description += `${cardio.join('、')} (距離・時間)`;
@@ -90,31 +68,55 @@ const WorkoutHistory = () => {
     if (strength.length > 0) {
       description += `${strength.join('、')} (${workoutConfig.maxSets}セット)`;
     }
-    
+
     return description;
   };
 
-    console.log('WorkoutHistory - useWorkoutConfig result:', {
-    workoutConfig,
-    isCardioExercise,
-    availableExercises
-  });
+  if (error) {
+    const getErrorMessage = () => {
+      if (error.response?.status === 401) {
+        return '認証情報が無効です。再度ログインしてください。';
+      }
+      if (error.code === 'ERR_NETWORK') {
+        return 'インターネット接続を確認してください。';
+      }
+      return `エラーが発生しました。': ${error.message}`;
+    };
+
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <p className="text-red-600">{getErrorMessage()}</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+            >
+              再試行
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+
 
   return (
     <Container maxWidth="md" sx={{ mt: 4 }}>
-      
       <Typography variant="h6">ワークアウト履歴</Typography>
       <Typography variant="body2" color="text.secondary">
         カスタム設定：{getConfigDescription()}
       </Typography>
       <Button
-      variant="outlined"
-      startIcon={<SettingsIcon />}
-      onClick={() => setDrawerOpen(true)}
+        variant="outlined"
+        startIcon={<SettingsIcon />}
+        onClick={() => setDrawerOpen(true)}
       >
         カスタマイズ
       </Button>
 
+      {/* カスタマイズドロワー */}
       <WorkoutCustomizationDrawer
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
@@ -128,85 +130,19 @@ const WorkoutHistory = () => {
         updateMaxSets={updateMaxSets}
       />
 
-
-
+      {/* 統計情報 */}
       <WorkoutStatistics workouts={workouts} loading={loading} />
-      
-      {loading && <CircularProgress />}
-      {error && <Alert severity="error">{error.message}</Alert>}
 
-      <WorkoutHistoryTable 
-      workouts={workouts}
-      workoutConfig={workoutConfig}
-      loading={loading}
-      isCardioExercise={isCardioExercise}
-      isStrengthExercise={isStrengthExercise}
+      {/* ワークアウト履歴テーブル */}
+      <WorkoutHistoryTable
+        workouts={workouts}
+        workoutConfig={workoutConfig}
+        loading={loading}
+        isCardioExercise={isCardioExercise}
+        isStrengthExercise={isStrengthExercise}
       />
-
-      {workouts.length > 0 && (
-        <TableContainer component={Paper}>
-          <Table stickyHeader>
-            <TableHead>
-              <TableRow>
-                <TableCell>日付</TableCell>
-                <TableCell>種目</TableCell>
-                <TableCell>セット／距離</TableCell>
-                <TableCell>時間</TableCell>
-                <TableCell>強度</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {workouts.map(workout => (
-                <React.Fragment key={workout.id}>
-                  <TableRow>
-                    <TableCell>{workout.date}</TableCell>
-                    <TableCell>{workout.exercise}</TableCell>
-                    <TableCell>
-                      {workout.isCardio
-                        ? `${workout.distance} km`
-                        : (
-                          <Button size="small" onClick={() => toggle(workout.id)}>
-                            {workout.sets} セット
-                          </Button>
-                        )
-                      }
-                    </TableCell>
-                    <TableCell>
-                      {workout.isCardio ? `${workout.duration} 分` : '-'}
-                    </TableCell>
-                    <TableCell>{workout.intensity}</TableCell>
-                  </TableRow>
-
-                  {!workout.isCardio && openId === workout.id && (
-                    <TableRow key={`${workout.id}-detail`}>
-                      <TableCell colSpan={5} sx={{ py: 0, border: 0 }}>
-                        <Collapse in>
-                          <ul style={{ margin: 8, paddingLeft: 16 }}>
-                            {workout.repsDetail.map(reps =>
-                              <li key={reps.setNumber}>
-                                {reps.setNumber}セット目
-                                {reps.reps}回
-                              </li>
-                            )}
-                          </ul>
-                        </Collapse>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </React.Fragment>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
-      {!loading && !error && workouts.length === 0 && (
-        <Alert severity="info">
-          トレーニング履歴がありません
-        </Alert>
-      )}
     </Container>
+  );
+};
 
-  )
-}
-
-export default WorkoutHistory
+export default WorkoutHistory;

--- a/frontend/src/services/StatisticsService.js
+++ b/frontend/src/services/StatisticsService.js
@@ -1,43 +1,55 @@
-const calculateWorkoutStats = (workouts) => {
-    const currentStats = workouts.reduce((acc, workout) => {
-    return {
-      totalDays: acc.totalDays + 1,
-      totalReps: acc.totalReps + (workout.totalReps || 0),
-      totalTime: acc.totalTime + (workout.totalTime || 0)
-    };
-  }, { totalDays: 0, totalReps: 0, totalTime: 0 });
+const calculateWorkoutStats = workouts => {
+  const currentStats = workouts.reduce(
+    (acc, workout) => {
+      return {
+        totalDays: acc.totalDays + 1,
+        totalReps: acc.totalReps + (workout.totalReps || 0),
+        totalTime: acc.totalTime + (workout.totalTime || 0),
+      };
+    },
+    { totalDays: 0, totalReps: 0, totalTime: 0 }
+  );
 
   console.log(currentStats);
 
-    // 前月のモックデータ
-    const lastMonthStats = {
+  // 前月のモックデータ
+  const lastMonthStats = {
     totalDays: 12,
     totalReps: 340,
-    totalTime: 150
+    totalTime: 150,
   };
 
-    const calculateChangeRate = (current, last) => {
+  const calculateChangeRate = (current, last) => {
     if (last === 0) {
       return current > 0 ? 100 : 0;
     }
     return Math.round(((current - last) / last) * 100);
   };
 
-return {
+  return {
     // 現在月
     currentTotalDays: currentStats.totalDays,
     currentTotalReps: currentStats.totalReps,
     currentTotalTime: currentStats.totalTime,
-    
+
     // 前月
     lastTotalDays: lastMonthStats.totalDays,
     lastTotalReps: lastMonthStats.totalReps,
     lastTotalTime: lastMonthStats.totalTime,
-    
+
     // 変化率
-    daysChangeRate: calculateChangeRate(currentStats.totalDays, lastMonthStats.totalDays),
-    repsChangeRate: calculateChangeRate(currentStats.totalReps, lastMonthStats.totalReps),
-    timeChangeRate: calculateChangeRate(currentStats.totalTime, lastMonthStats.totalTime)
+    daysChangeRate: calculateChangeRate(
+      currentStats.totalDays,
+      lastMonthStats.totalDays
+    ),
+    repsChangeRate: calculateChangeRate(
+      currentStats.totalReps,
+      lastMonthStats.totalReps
+    ),
+    timeChangeRate: calculateChangeRate(
+      currentStats.totalTime,
+      lastMonthStats.totalTime
+    ),
   };
 };
 

--- a/frontend/src/services/TransformWorkoutData.js
+++ b/frontend/src/services/TransformWorkoutData.js
@@ -1,4 +1,4 @@
-const transformWorkoutData = (apiData) => {
+const transformWorkoutData = apiData => {
   if (!Array.isArray(apiData) || apiData.length === 0) {
     return [];
   }
@@ -6,22 +6,22 @@ const transformWorkoutData = (apiData) => {
   const groupedByDate = apiData.reduce((acc, workout) => {
     const dateKey = new Date(workout.date).toLocaleDateString('ja-JP', {
       month: 'numeric',
-      day: 'numeric'
+      day: 'numeric',
     });
-    
+
     if (!acc[dateKey]) {
       acc[dateKey] = {
         date: dateKey,
         exercises: {},
         totalReps: 0,
-        totalTime: 0
+        totalTime: 0,
       };
     }
 
     if (workout.exerciseType === 'cardio') {
       acc[dateKey].exercises[workout.exercise] = {
         distance: workout.distance,
-        duration: workout.duration
+        duration: workout.duration,
       };
       acc[dateKey].totalTime += workout.duration || 0;
     } else if (workout.exerciseType === 'strength') {
@@ -41,4 +41,4 @@ const transformWorkoutData = (apiData) => {
   return Object.values(groupedByDate);
 };
 
-export default transformWorkoutData;  
+export default transformWorkoutData;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -12,17 +12,20 @@ const apiClient = axios.create({
 
 // リクエストインターセプター: 全てのリクエストにJWTトークンを自動追加
 apiClient.interceptors.request.use(
-  (config) => {
+  config => {
     const token = localStorage.getItem('token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
-      console.log('🔐 JWT Token added to request:', `Bearer ${token.substring(0, 20)}...`);
+      console.log(
+        '🔐 JWT Token added to request:',
+        `Bearer ${token.substring(0, 20)}...`
+      );
     } else {
       console.warn('⚠️ No JWT token found in localStorage');
     }
     return config;
   },
-  (error) => {
+  error => {
     console.error('❌ Request interceptor error:', error);
     return Promise.reject(error);
   }
@@ -30,12 +33,14 @@ apiClient.interceptors.request.use(
 
 // レスポンスインターセプター: 401エラーの処理
 apiClient.interceptors.response.use(
-  (response) => {
+  response => {
     return response;
   },
-  (error) => {
+  error => {
     if (error.response?.status === 401) {
-      console.error('🚫 401 Unauthorized - JWT token may be invalid or expired');
+      console.error(
+        '🚫 401 Unauthorized - JWT token may be invalid or expired'
+      );
       // トークンが無効な場合は削除
       localStorage.removeItem('token');
       // ログインページにリダイレクト（必要に応じて）

--- a/frontend/src/services/errorHandler.ts
+++ b/frontend/src/services/errorHandler.ts
@@ -1,5 +1,10 @@
 import { AxiosError } from 'axios';
-import { ApiErrorResponse, ErrorProcessResult, SimpleAppError, SimpleErrorType } from '../types/error';
+import {
+  ApiErrorResponse,
+  ErrorProcessResult,
+  SimpleAppError,
+  SimpleErrorType,
+} from '../types/error';
 
 function isAxiosError(error: unknown): error is AxiosError {
   return (
@@ -10,88 +15,96 @@ function isAxiosError(error: unknown): error is AxiosError {
   );
 }
 
-export const handleApiError = (error : unknown):never => {
+export const handleApiError = (error: unknown): never => {
   console.error('Goal API Error:', error);
-    console.log('🔍 エラー判定:', {
+  console.log('🔍 エラー判定:', {
     isAxiosErrorInstance: error instanceof AxiosError,
-    hasIsAxiosErrorProperty: typeof error === 'object' && error !== null && 'isAxiosError' in error,
-    isAxiosErrorValue: typeof error === 'object' && error !== null && (error as any).isAxiosError
+    hasIsAxiosErrorProperty:
+      typeof error === 'object' && error !== null && 'isAxiosError' in error,
+    isAxiosErrorValue:
+      typeof error === 'object' &&
+      error !== null &&
+      (error as any).isAxiosError,
   });
 
   function getAxiosErrorMessage(error: AxiosError): string {
-  const responseData = error.response?.data as ApiErrorResponse;
-  return responseData?.error || 'エラーが発生しました';
-}
-
-function getAxiosErrorType(error: AxiosError): SimpleErrorType {
-  if (error.response) {
-    return 'API_ERROR';   
-  } else if (error.request) {
-    return 'NETWORK_ERROR'; 
-  } else {
-    return 'UNKNOWN_ERROR';
+    const responseData = error.response?.data as ApiErrorResponse;
+    return responseData?.error || 'エラーが発生しました';
   }
-};
 
-function processAxiosError(error: AxiosError): ErrorProcessResult {
-  
-  if (error.response) {
-    const statusCode = error.response.status;
-    const responseData = error.response.data as ApiErrorResponse;
+  function getAxiosErrorType(error: AxiosError): SimpleErrorType {
+    if (error.response) {
+      return 'API_ERROR';
+    } else if (error.request) {
+      return 'NETWORK_ERROR';
+    } else {
+      return 'UNKNOWN_ERROR';
+    }
+  }
 
-switch (statusCode) {
-      case 401:
-        return {
-          type: 'API_ERROR',
-          userMessage: 'ログインが必要です',
-          statusCode: statusCode
-        };
-      case 403:
-        return {
-          type: 'API_ERROR', 
-          userMessage: 'アクセス権限がありません',
-          statusCode: statusCode
-        };
-      case 404:
-        return {
-          type: 'API_ERROR',
-          userMessage: 'データが見つかりません',
-          statusCode: statusCode
-        };
-      case 500:
-        return {
-          type: 'API_ERROR',
-          userMessage: 'サーバーでエラーが発生しました',
-          statusCode: statusCode
-        };
-      default:
-        return {
-          type: 'API_ERROR',
-          userMessage: responseData?.error || 'エラーが発生しました',
-          statusCode: statusCode
-        };
-}
-  } else if (error.request) {
+  function processAxiosError(error: AxiosError): ErrorProcessResult {
+    if (error.response) {
+      const statusCode = error.response.status;
+      const responseData = error.response.data as ApiErrorResponse;
+
+      switch (statusCode) {
+        case 401:
+          return {
+            type: 'API_ERROR',
+            userMessage: 'ログインが必要です',
+            statusCode: statusCode,
+          };
+        case 403:
+          return {
+            type: 'API_ERROR',
+            userMessage: 'アクセス権限がありません',
+            statusCode: statusCode,
+          };
+        case 404:
+          return {
+            type: 'API_ERROR',
+            userMessage: 'データが見つかりません',
+            statusCode: statusCode,
+          };
+        case 500:
+          return {
+            type: 'API_ERROR',
+            userMessage: 'サーバーでエラーが発生しました',
+            statusCode: statusCode,
+          };
+        default:
+          return {
+            type: 'API_ERROR',
+            userMessage: responseData?.error || 'エラーが発生しました',
+            statusCode: statusCode,
+          };
+      }
+    } else if (error.request) {
+      return {
+        type: 'NETWORK_ERROR',
+        userMessage: 'ネットワーク接続を確認してください',
+      };
+    }
+
     return {
-      type: 'NETWORK_ERROR',
-      userMessage: 'ネットワーク接続を確認してください'
+      type: 'UNKNOWN_ERROR',
+      userMessage: '予期しないエラーが発生しました',
     };
   }
-  
-  return {
-    type: 'UNKNOWN_ERROR',
-    userMessage: '予期しないエラーが発生しました'
-  };
-}
-if(isAxiosError(error)){
-  console.log('✅ AxiosErrorとして処理');
+  if (isAxiosError(error)) {
+    console.log('✅ AxiosErrorとして処理');
     const result = processAxiosError(error);
-    throw new SimpleAppError(result.type, result.userMessage, result.statusCode);
-} else {
-  console.log('❌ AxiosErrorではない');
-  const message = error instanceof Error ? error.message :'エラーが発生しました';
-  throw new SimpleAppError('UNKNOWN_ERROR', message);
-}
+    throw new SimpleAppError(
+      result.type,
+      result.userMessage,
+      result.statusCode
+    );
+  } else {
+    console.log('❌ AxiosErrorではない');
+    const message =
+      error instanceof Error ? error.message : 'エラーが発生しました';
+    throw new SimpleAppError('UNKNOWN_ERROR', message);
+  }
 };
 
 export default handleApiError;

--- a/frontend/src/services/exerciseService.ts
+++ b/frontend/src/services/exerciseService.ts
@@ -3,7 +3,9 @@ import { EXERCISE_OPTIONS, WORKOUT_TYPES } from '../config/exercise';
 // 運動関連のビジネスロジックを分離
 
 const getExerciseType = (exerciseName: string): string => {
-  const exercise = EXERCISE_OPTIONS.find(exercise => exercise.name === exerciseName);
+  const exercise = EXERCISE_OPTIONS.find(
+    exercise => exercise.name === exerciseName
+  );
   return exercise ? exercise.type : WORKOUT_TYPES.STRENGTH;
 };
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2,7 +2,6 @@
 // API Communication Types - API通信全般の型定義
 // ============================================================================
 
-
 /**
  * HTTP メソッドの型安全な定義
  * RESTful API設計に準拠
@@ -13,16 +12,16 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
  * HTTP ステータスコードの型定義
  * 主要なステータスコードを網羅
  */
-export type HttpStatusCode = 
-  | 200  // OK
-  | 201  // Created
-  | 204  // No Content
-  | 400  // Bad Request
-  | 401  // Unauthorized
-  | 403  // Forbidden
-  | 404  // Not Found
-  | 422  // Unprocessable Entity
-  | 429  // Too Many Requests
+export type HttpStatusCode =
+  | 200 // OK
+  | 201 // Created
+  | 204 // No Content
+  | 400 // Bad Request
+  | 401 // Unauthorized
+  | 403 // Forbidden
+  | 404 // Not Found
+  | 422 // Unprocessable Entity
+  | 429 // Too Many Requests
   | 500; // Internal Server Error
 
 /**
@@ -30,11 +29,11 @@ export type HttpStatusCode =
  * 全APIエンドポイントの共通構造
  */
 export interface BaseApiResponse<T = unknown> {
-  data: T;                                // レスポンスデータ（ジェネリック）
-  message: string;                        // 操作結果メッセージ
-  status: 'success' | 'error';            // 操作ステータス
-  timestamp: string;                      // レスポンス時刻（ISO 8601）
-  requestId?: string;                     // リクエスト追跡ID（デバッグ用）
+  data: T; // レスポンスデータ（ジェネリック）
+  message: string; // 操作結果メッセージ
+  status: 'success' | 'error'; // 操作ステータス
+  timestamp: string; // レスポンス時刻（ISO 8601）
+  requestId?: string; // リクエスト追跡ID（デバッグ用）
 }
 
 /**
@@ -42,12 +41,12 @@ export interface BaseApiResponse<T = unknown> {
  * 一覧API共通のページネーション
  */
 export interface PaginationInfo {
-  currentPage: number;                    // 現在ページ（1始まり）
-  totalPages: number;                     // 総ページ数
-  totalItems: number;                     // 総アイテム数
-  itemsPerPage: number;                   // 1ページ辺りのアイテム数
-  hasNextPage: boolean;                   // 次ページ存在フラグ
-  hasPreviousPage: boolean;               // 前ページ存在フラグ
+  currentPage: number; // 現在ページ（1始まり）
+  totalPages: number; // 総ページ数
+  totalItems: number; // 総アイテム数
+  itemsPerPage: number; // 1ページ辺りのアイテム数
+  hasNextPage: boolean; // 次ページ存在フラグ
+  hasPreviousPage: boolean; // 前ページ存在フラグ
 }
 
 /**
@@ -55,7 +54,7 @@ export interface PaginationInfo {
  * 一覧取得APIの標準レスポンス
  */
 export interface PaginatedApiResponse<T> extends BaseApiResponse<T[]> {
-  pagination: PaginationInfo;             // ページネーション情報
+  pagination: PaginationInfo; // ページネーション情報
 }
 
 // ============================================================================
@@ -67,10 +66,10 @@ export interface PaginatedApiResponse<T> extends BaseApiResponse<T[]> {
  * フィールド別バリデーションエラー対応
  */
 export interface ApiErrorDetail {
-  field: string;                          // エラー対象フィールド名
-  message: string;                        // エラーメッセージ
-  code: string;                           // エラーコード
-  value?: unknown;                        // 無効な値（デバッグ用）
+  field: string; // エラー対象フィールド名
+  message: string; // エラーメッセージ
+  code: string; // エラーコード
+  value?: unknown; // 無効な値（デバッグ用）
 }
 
 /**
@@ -78,13 +77,13 @@ export interface ApiErrorDetail {
  * 全エラーレスポンスの標準構造
  */
 export interface ApiError {
-  status: 'error';                        // 固定値
-  code: string;                           // エラーコード（例：VALIDATION_ERROR）
-  message: string;                        // ユーザー向けエラーメッセージ
-  details?: ApiErrorDetail[];             // 詳細エラー情報
-  timestamp: string;                      // エラー発生時刻
-  requestId?: string;                     // リクエスト追跡ID
-  stack?: string;                         // スタックトレース（開発環境のみ）
+  status: 'error'; // 固定値
+  code: string; // エラーコード（例：VALIDATION_ERROR）
+  message: string; // ユーザー向けエラーメッセージ
+  details?: ApiErrorDetail[]; // 詳細エラー情報
+  timestamp: string; // エラー発生時刻
+  requestId?: string; // リクエスト追跡ID
+  stack?: string; // スタックトレース（開発環境のみ）
 }
 
 /**
@@ -92,10 +91,10 @@ export interface ApiError {
  * 通信障害、タイムアウト等の処理
  */
 export interface NetworkError {
-  type: 'network';                        // エラータイプ識別
-  message: string;                        // エラーメッセージ
-  code?: string;                          // エラーコード（例：TIMEOUT）
-  isRetryable: boolean;                   // リトライ可能フラグ
+  type: 'network'; // エラータイプ識別
+  message: string; // エラーメッセージ
+  code?: string; // エラーコード（例：TIMEOUT）
+  isRetryable: boolean; // リトライ可能フラグ
 }
 
 /**
@@ -103,10 +102,10 @@ export interface NetworkError {
  * JWT有効期限切れ、権限不足等
  */
 export interface AuthenticationError {
-  type: 'authentication';                 // エラータイプ識別
-  message: string;                        // エラーメッセージ
+  type: 'authentication'; // エラータイプ識別
+  message: string; // エラーメッセージ
   code: 'TOKEN_EXPIRED' | 'TOKEN_INVALID' | 'INSUFFICIENT_PERMISSIONS';
-  redirectTo?: string;                    // リダイレクト先URL
+  redirectTo?: string; // リダイレクト先URL
 }
 
 /**
@@ -124,13 +123,13 @@ export type AppError = ApiError | NetworkError | AuthenticationError;
  * Axios設定の型安全ラッパー
  */
 export interface ApiRequestConfig {
-  method: HttpMethod;                     // HTTPメソッド
-  url: string;                            // エンドポイントURL
-  params?: Record<string, unknown>;       // URLパラメータ
-  data?: unknown;                         // リクエストボディ
-  headers?: Record<string, string>;       // カスタムヘッダー
-  timeout?: number;                       // タイムアウト時間（ミリ秒）
-  withCredentials?: boolean;              // クレデンシャル含有フラグ
+  method: HttpMethod; // HTTPメソッド
+  url: string; // エンドポイントURL
+  params?: Record<string, unknown>; // URLパラメータ
+  data?: unknown; // リクエストボディ
+  headers?: Record<string, string>; // カスタムヘッダー
+  timeout?: number; // タイムアウト時間（ミリ秒）
+  withCredentials?: boolean; // クレデンシャル含有フラグ
 }
 
 /**
@@ -138,9 +137,9 @@ export interface ApiRequestConfig {
  * 一覧取得API共通パラメータ
  */
 export interface PaginationParams {
-  page?: number;                          // ページ番号（デフォルト：1）
-  limit?: number;                         // 取得件数（デフォルト：20）
-  offset?: number;                        // オフセット（ページ番号と排他）
+  page?: number; // ページ番号（デフォルト：1）
+  limit?: number; // 取得件数（デフォルト：20）
+  offset?: number; // オフセット（ページ番号と排他）
 }
 
 /**
@@ -148,8 +147,8 @@ export interface PaginationParams {
  * 一覧取得APIのソート機能
  */
 export interface SortParams {
-  sortBy?: string;                        // ソート対象フィールド
-  sortOrder?: 'asc' | 'desc';            // ソート方向
+  sortBy?: string; // ソート対象フィールド
+  sortOrder?: 'asc' | 'desc'; // ソート方向
 }
 
 /**
@@ -157,15 +156,18 @@ export interface SortParams {
  * 一覧取得APIの検索機能
  */
 export interface SearchParams {
-  q?: string;                             // 検索クエリ
-  filters?: Record<string, unknown>;      // フィルター条件
+  q?: string; // 検索クエリ
+  filters?: Record<string, unknown>; // フィルター条件
 }
 
 /**
  * 統合リクエストパラメータ型
  * 一覧取得APIの全機能を統合
  */
-export interface ListRequestParams extends PaginationParams, SortParams, SearchParams {
+export interface ListRequestParams
+  extends PaginationParams,
+    SortParams,
+    SearchParams {
   // 追加の共通パラメータがあればここに定義
 }
 
@@ -178,13 +180,13 @@ export interface ListRequestParams extends PaginationParams, SortParams, SearchP
  * JWTトークンに含まれる情報
  */
 export interface JwtPayload {
-  sub: string;                            // ユーザーID（subject）
-  iat: number;                            // 発行時刻（issued at）
-  exp: number;                            // 有効期限（expiration time）
-  iss?: string;                           // 発行者（issuer）
-  aud?: string;                           // 対象者（audience）
-  email?: string;                         // ユーザーメールアドレス
-  role?: string;                          // ユーザー権限
+  sub: string; // ユーザーID（subject）
+  iat: number; // 発行時刻（issued at）
+  exp: number; // 有効期限（expiration time）
+  iss?: string; // 発行者（issuer）
+  aud?: string; // 対象者（audience）
+  email?: string; // ユーザーメールアドレス
+  role?: string; // ユーザー権限
 }
 
 /**
@@ -192,10 +194,10 @@ export interface JwtPayload {
  * JWT認証システムのトークン管理
  */
 export interface AuthTokens {
-  accessToken: string;                    // アクセストークン
-  refreshToken?: string;                  // リフレッシュトークン（将来対応）
-  tokenType: 'Bearer';                    // トークンタイプ
-  expiresIn: number;                      // 有効期限（秒）
+  accessToken: string; // アクセストークン
+  refreshToken?: string; // リフレッシュトークン（将来対応）
+  tokenType: 'Bearer'; // トークンタイプ
+  expiresIn: number; // 有効期限（秒）
 }
 
 /**
@@ -203,9 +205,9 @@ export interface AuthTokens {
  * 認証API用
  */
 export interface LoginRequest {
-  email: string;                          // メールアドレス
-  password: string;                       // パスワード
-  rememberMe?: boolean;                   // ログイン保持フラグ
+  email: string; // メールアドレス
+  password: string; // パスワード
+  rememberMe?: boolean; // ログイン保持フラグ
 }
 
 /**
@@ -214,14 +216,12 @@ export interface LoginRequest {
  */
 export interface LoginResponse {
   user: {
-    id: number;                           // ユーザーID
-    email: string;                        // メールアドレス
-    name: string;                         // ユーザー名
+    id: number; // ユーザーID
+    email: string; // メールアドレス
+    name: string; // ユーザー名
   };
-  tokens: AuthTokens;                     // 認証トークン
+  tokens: AuthTokens; // 認証トークン
 }
-
-
 
 // ============================================================================
 // API Client Types - APIクライアント型定義
@@ -232,11 +232,11 @@ export interface LoginResponse {
  * APIクライアントクラスの設定
  */
 export interface ApiClientConfig {
-  baseURL: string;                        // ベースURL
-  timeout: number;                        // タイムアウト時間
-  retryAttempts: number;                  // リトライ回数
-  retryDelay: number;                     // リトライ間隔（ミリ秒）
-  enableLogging: boolean;                 // ログ出力フラグ
+  baseURL: string; // ベースURL
+  timeout: number; // タイムアウト時間
+  retryAttempts: number; // リトライ回数
+  retryDelay: number; // リトライ間隔（ミリ秒）
+  enableLogging: boolean; // ログ出力フラグ
 }
 
 /**
@@ -244,10 +244,10 @@ export interface ApiClientConfig {
  * APIクライアント統一レスポンス
  */
 export interface ApiClientResponse<T> {
-  data: T;                                // レスポンスデータ
-  status: HttpStatusCode;                 // HTTPステータスコード
-  headers: Record<string, string>;        // レスポンスヘッダー
-  config: ApiRequestConfig;               // リクエスト設定
+  data: T; // レスポンスデータ
+  status: HttpStatusCode; // HTTPステータスコード
+  headers: Record<string, string>; // レスポンスヘッダー
+  config: ApiRequestConfig; // リクエスト設定
 }
 
 /**
@@ -270,8 +270,14 @@ export interface ApiClient {
  * 基本クエリキータイプ
  * React Queryキーの型安全な管理
  */
-export type QueryKey = readonly (string | number | boolean | Record<string, unknown> | null | undefined)[];
-
+export type QueryKey = readonly (
+  | string
+  | number
+  | boolean
+  | Record<string, unknown>
+  | null
+  | undefined
+)[];
 
 // ============================================================================
 // Export Utility Types - エクスポート用ユーティリティ型
@@ -305,4 +311,4 @@ export type OptionalOnly<T> = {
   [K in keyof T as T[K] extends Required<T>[K] ? never : K]: T[K];
 };
 
-// Tree shakingとバンドル最適化のため、named exportのみ使用 
+// Tree shakingとバンドル最適化のため、named exportのみ使用

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,4 +1,3 @@
-
 export interface User {
   id: string | number;
   email: string;

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -4,11 +4,7 @@ export interface ApiErrorResponse {
   details?: unknown;
 }
 
-
-export type SimpleErrorType = 
-  | 'API_ERROR'      
-  | 'NETWORK_ERROR'  
-  | 'UNKNOWN_ERROR';
+export type SimpleErrorType = 'API_ERROR' | 'NETWORK_ERROR' | 'UNKNOWN_ERROR';
 
 export interface ErrorProcessResult {
   type: SimpleErrorType;
@@ -16,11 +12,10 @@ export interface ErrorProcessResult {
   statusCode?: number;
 }
 
-
-  export class SimpleAppError extends Error {
+export class SimpleAppError extends Error {
   public readonly type: SimpleErrorType;
   public readonly statusCode: number | undefined;
-  
+
   constructor(type: SimpleErrorType, message: string, statusCode?: number) {
     super(message);
     this.name = 'SimpleAppError';
@@ -28,4 +23,3 @@ export interface ErrorProcessResult {
     this.statusCode = statusCode;
   }
 }
-

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -1,10 +1,7 @@
-
 export type FeedbackType = 'success' | 'error' | 'info' | 'warning';
-
 
 export interface FeedbackState {
   message: string;
   type: FeedbackType;
   visible: boolean;
 }
-

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,8 +1,5 @@
-
-
 // Feedback 関連型定義
 export type { FeedbackState, FeedbackType } from './feedback';
-
 
 // API 通信型定義
 export type {
@@ -14,7 +11,10 @@ export type {
   ApiError,
   ApiErrorDetail,
   // リクエスト型
-  ApiRequestConfig, AppError, AuthenticationError, AuthTokens,
+  ApiRequestConfig,
+  AppError,
+  AuthenticationError,
+  AuthTokens,
   // レスポンス型
   BaseApiResponse,
   // ユーティリティ型
@@ -24,13 +24,22 @@ export type {
   HttpMethod,
   HttpStatusCode,
   // 認証型
-  JwtPayload, ListRequestParams, LoginRequest,
-  LoginResponse, NetworkError, OptionalOnly, PaginatedApiResponse, PaginationInfo, PaginationParams,
+  JwtPayload,
+  ListRequestParams,
+  LoginRequest,
+  LoginResponse,
+  NetworkError,
+  OptionalOnly,
+  PaginatedApiResponse,
+  PaginationInfo,
+  PaginationParams,
   // React Query 型
-  QueryKey, RequiredOnly, SearchParams, SortParams, UnwrapPromise
+  QueryKey,
+  RequiredOnly,
+  SearchParams,
+  SortParams,
+  UnwrapPromise,
 } from './api';
-
-
 
 // ============================================================================
 // 開発者向けユーティリティ型
@@ -51,10 +60,10 @@ export type DebugInfo<T> = T & {
  * 全コンポーネントが持つべき基本プロパティ
  */
 export interface BaseComponentProps {
-  className?: string;                     // CSSクラス名
-  children?: React.ReactNode;             // 子要素
-  testId?: string;                        // テスト用ID
-  'data-*'?: string;                      // データ属性
+  className?: string; // CSSクラス名
+  children?: React.ReactNode; // 子要素
+  testId?: string; // テスト用ID
+  'data-*'?: string; // データ属性
 }
 
 /**
@@ -62,9 +71,9 @@ export interface BaseComponentProps {
  * ローディング・エラー状態を持つコンポーネント
  */
 export interface AsyncComponentProps extends BaseComponentProps {
-  isLoading?: boolean;                    // ローディング状態
-  error?: string | null;                  // エラーメッセージ
-  onRetry?: () => void;                   // リトライ関数
+  isLoading?: boolean; // ローディング状態
+  error?: string | null; // エラーメッセージ
+  onRetry?: () => void; // リトライ関数
 }
 
 /**
@@ -72,10 +81,10 @@ export interface AsyncComponentProps extends BaseComponentProps {
  * フォーム関連コンポーネントの基本プロパティ
  */
 export interface FormComponentProps extends BaseComponentProps {
-  disabled?: boolean;                     // 無効化状態
-  required?: boolean;                     // 必須フィールド
-  error?: string;                         // フィールドエラー
-  touched?: boolean;                      // タッチ状態
+  disabled?: boolean; // 無効化状態
+  required?: boolean; // 必須フィールド
+  error?: string; // フィールドエラー
+  touched?: boolean; // タッチ状態
 }
 
 // ============================================================================
@@ -86,22 +95,22 @@ export interface FormComponentProps extends BaseComponentProps {
  * MVP開発段階の識別型
  * 機能の開発段階を管理
  */
-export type MvpFeatureStatus = 
-  | 'planned'                             // 計画段階
-  | 'in_development'                      // 開発中
-  | 'testing'                             // テスト中
-  | 'completed'                           // 完了
-  | 'deferred';                           // 延期
+export type MvpFeatureStatus =
+  | 'planned' // 計画段階
+  | 'in_development' // 開発中
+  | 'testing' // テスト中
+  | 'completed' // 完了
+  | 'deferred'; // 延期
 
 /**
  * MVP機能フラグ型
  * 機能の有効/無効を制御
  */
 export interface MvpFeatureFlags {
-  realTimeUpdates: boolean;               // リアルタイム更新
-  advancedFiltering: boolean;             // 高度なフィルタリング
-  dataExport: boolean;                    // データエクスポート
-  pushNotifications: boolean;             // プッシュ通知
+  realTimeUpdates: boolean; // リアルタイム更新
+  advancedFiltering: boolean; // 高度なフィルタリング
+  dataExport: boolean; // データエクスポート
+  pushNotifications: boolean; // プッシュ通知
 }
 
 /**
@@ -155,12 +164,11 @@ export const TYPE_DEFINITIONS_VERSION = '1.0.0' as const;
  * バックエンドAPIとの型整合性確認
  */
 export interface TypeCompatibility {
-  apiVersion: string;                     // 対応するAPIバージョン
+  apiVersion: string; // 対応するAPIバージョン
   typeVersion: typeof TYPE_DEFINITIONS_VERSION;
-  lastUpdated: string;                    // 最終更新日時
-  breakingChanges?: string[];             // 破壊的変更のリスト
+  lastUpdated: string; // 最終更新日時
+  breakingChanges?: string[]; // 破壊的変更のリスト
 }
 
 // TypeScript設定による型チェック強化
-export type { } from './api';
-
+export type {} from './api';


### PR DESCRIPTION
- tbody レンダリングをコンフィグベースから過去のワークアウトベースへ変更
- データアクセスを workoutConfig.exercises[name] から workout.exercises[name] に修正
- テーブル行での実際のワークアウトデータ表示を有効化
- 日付、運動データ、合計列のレンダリングを適切に追加 修正内容: ヘッダーのみでデータが表示されない空のテーブル
結果: ユーザーが実際のワークアウト履歴データを確認可能