### PR TITLE
refactor(#76): ワークアウトテストの認証設定を改善

### DIFF
--- a/backend/routes/workouts.js
+++ b/backend/routes/workouts.js
@@ -157,7 +157,6 @@ router.post('/', authMiddleware, async (req, res) => {
       message: "ワークアウトが正常に作成されました",
       workout: workoutData,
     });
-
   } catch (error) {
     if (error.name === 'SequelizeValidationError') {
       return res.status(400).json({

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,13 +2,14 @@ require('dotenv').config();
 const app = require('./app');
 const port = process.env.PORT;
 
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Server is running on http://localhost:${port}`);
+  });
+}
 
+module.exports = app;
 
-const server = app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
-});
-
-module.exports = server;
 
 
 


### PR DESCRIPTION
- 手動JWTトークン生成を実際のログインAPI呼び出しに変更
- モックトークン作成ではなく実際の認証フローを使用

結果:
strength系ワークアウト作成テストクリア