### PR TITLE
feat(#76): ワークアウトAPI機能とJWT認証エラーハンドリングの改善

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -13,23 +13,37 @@ app.use("/authrouter", authRouter);
 app.use("/workouts", workouts);
 
 app.use((err, req, res, next) => {
+
   if (err.name === 'UnauthorizedError') {
-    return res.status(401).json({ 
-      error: '認証エラー - リクエストにユーザー情報がありません'
-    });
+
+    if (err.code === 'credentials_required') {
+      return res.status(401).json({
+        error: '認証エラー - リクエストにユーザー情報がありません'
+      });
+    }
+
+    if (err.code === 'invalid_token') {
+      if (err.inner && err.inner.name === 'JsonWebTokenError') {
+        return res.status(401).json({ 
+          error: '認証エラー - トークンが無効です'
+        });
+      }
+
+      if (err.inner && err.inner.name === 'TokenExpiredError') {
+        return res.status(401).json({
+          error: "認証エラー - トークンの有効期限が切れています"
+        });
+      }
+
+      return res.status(401).json({
+        error: '認証エラー - 予期しないエラーが発生しました'
+      });
+    }
   }
 
-  if (err.name === 'JsonWebTokenError') {
-    return res.status(401).json({
-      error: '認証エラー - トークンが無効です'
-    });
-  }
-
-   if (err.name === 'TokenExpiredError') {
-    return res.status(401).json({
-      error: "認証エラー - トークンの有効期限が切れています"
-    });
-  }
+  return res.status(401).json({
+    error: '認証エラー - 予期しないエラーが発生しました'
+  });
 
   return res.status(500).json({
     error: 'サーバーエラー - 予期しないエラーが発生しました'

--- a/backend/tests/workouts.test.js
+++ b/backend/tests/workouts.test.js
@@ -86,5 +86,47 @@ describe('ワークアウト機能', () => {
 
       expect(response.body.error).toBe('認証エラー - リクエストにユーザー情報がありません');
     });
+    
+    test('無効なトークンでワークアウト作成に失敗する', async () => {
+      const workoutData = {
+        exercise: 'ベンチプレス',
+        exerciseType: 'strength',
+        intensity: '中',
+        setNumber: 1,
+        repsNumber: [{ reps: 10 }]
+      };
+
+      const response = await request(app)
+        .post('/workouts')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(workoutData)
+        .expect(401);
+
+      expect(response.body.error).toBe('認証エラー - トークンが無効です');
+    });
+
+    test('トークンの有効期限が切れている場合、ワークアウト作成に失敗する', async () => {
+      const expiredToken = jwt.sign(
+        { id: testUser.id },
+        process.env.JWT_SECRET_KEY,
+        { expiresIn: '-1s' }
+      );
+
+      const workoutData = {
+        exercise: 'ベンチプレス',
+        exerciseType: 'strength',
+        intensity: '中',
+        setNumber: 1,
+        repsNumber: [{ reps: 10 }]
+      };
+
+      const response = await request(app)
+        .post('/workouts')
+        .set('Authorization', `Bearer ${expiredToken}`)
+        .send(workoutData)
+        .expect(401);
+
+      expect(response.body.error).toBe('認証エラー - トークンの有効期限が切れています');
+    });
   });
 });


### PR DESCRIPTION
## 変更内容
WT認証エラーハンドリングの改善
- `credentials_required`エラーの適切な処理を追加
- `invalid_token`エラーの詳細判定（JsonWebTokenError対応）
- `TokenExpiredError`の専用エラーメッセージ追加
- 各エラータイプに応じた適切なHTTPステータスコードとメッセージを返すように改善

## テスト結果
- [x] 認証済みユーザーのワークアウト作成
- [x] 認証なしでのアクセス拒否
- [x] 無効なトークンでのエラーハンドリング
- [x] 期限切れトークンでのエラーハンドリング
- [x] 各種JWT認証エラーの適切な処理