### PR TITLE
refactor(#76): テストユーザー生成機能を動的パラメーター対応に改善

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -24,15 +24,22 @@ afterAll(async () => {
 });
 
 // テスト用のユーティリティ関数
-global.createTestUser = async () => {
+global.createTestUser = async (options = {}) => {
   const { User } = require('../models');
   const bcrypt = require('bcrypt');
+
+  const {
+    username = 'testuser',
+    email = 'test@example.com',
+    password = 'password123'
+  } = options;
+
   const salt = await bcrypt.genSalt(10);
-  const hashedPassword = await bcrypt.hash('password123', salt);
+  const hashedPassword = await bcrypt.hash(password, salt);
 
   return await User.create({
-    username: 'testuser',
-    email: 'test@example.com',
+    username,
+    email,
     password: hashedPassword
   });
 };


### PR DESCRIPTION
- global.createTestUser関数に分割代入による動的パラメーター注入機能を追加
- テストユーザーの柔軟な生成とカスタマイズが可能に
- ワークアウトテストでの新機能適用とデータ分離強化