### PR TITLE
feat(front): アプリ起動時のスプラッシュスクリーンと認証ベース遷移を実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Logout from './components/Logout';
 import Navbar from './components/Navbar';
 import PrivateRoute from './components/PrivateRoute';
 import PublicRoute from './components/PublicRoute';
+import SplashScreen from './components/SplashScreen';
 import DashboardPage from './pages/Dashboard';
 import Register from './pages/Register';
 import WorkoutFormPage from './pages/WorkoutForm';
@@ -21,6 +22,7 @@ function App() {
       <AuthContextProvider>
         <Navbar />
         <Routes>
+          <Route path="/" element={<SplashScreen />} />
           <Route
             path="/dashboard"
             element={<PrivateRoute element={<DashboardPage />} />}

--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, LinearProgress } from '@mui/material';
+import FitnessCenterIcon from '@mui/icons-material/FitnessCenter';
+import { useAuth } from './Hook';
+
+const SplashScreen = () => {
+  const { user, loading } = useAuth();
+  const navigate = useNavigate();
+  
+  useEffect(() => {
+    if (!loading) {
+      const timer = setTimeout(() => {
+        if (user) {
+          navigate('/dashboard', { replace: true });
+        } else {
+          navigate('/login', { replace: true });
+        }
+      }, 2000);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [user, loading, navigate]);
+  
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        backgroundColor: '#F8FAF8',
+        '@keyframes fadeIn': {
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        },
+        animation: 'fadeIn 0.5s ease-in',
+      }}
+    >
+      <FitnessCenterIcon 
+        sx={{ 
+          fontSize: 80, 
+          color: 'primary.main',
+          mb: 2 
+        }} 
+      />
+      <Typography 
+        variant="h4" 
+        component="h1"
+        sx={{ mb: 4 }}
+      >
+        FitStart
+      </Typography>
+      <LinearProgress 
+        sx={{ 
+          width: 200,
+          height: 4,
+          borderRadius: 2
+        }} 
+      />
+    </Box>
+  );
+};
+
+export default SplashScreen;


### PR DESCRIPTION
- SplashScreenコンポーネントを新規作成（FitStartロゴ、2秒表示）
- 認証状態に応じた自動遷移（ログイン済み→/dashboard、未ログイン→/login）
- loading状態を考慮してrace conditionを防止
- ルートパス「/」にスプラッシュスクリーンを設定
