### PR TITLE
feat(#119): Strava OAuth認証フローを実装

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,3 +31,8 @@ CORS_ORIGIN=http://localhost:5173
 # セキュリティ設定
 BCRYPT_ROUNDS=12
 
+STRAVA_CLIENT_ID=あなたのクライアントID
+STRAVA_CLIENT_SECRET=あなたのクライアントシークレット
+STRAVA_REDIRECT_URI=http://localhost:8000/api/strava/callback
+ENCRYPTION_KEY=32文字のランダムな文字列を生成
+

--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ const app = express();
 const cors = require('cors');
 const authRouter = require("./routes/authRoutes");
 const workouts = require('./routes/workouts');
+const stravaRoutes = require('./routes/stravaRoutes');
 
 app.use(cors({
   origin: [
@@ -15,6 +16,7 @@ app.use(cors({
 app.use(express.json());
 app.use("/authrouter", authRouter);
 app.use("/workouts", workouts);
+app.use("/api/strava", stravaRoutes);
 
 app.use((err, req, res, next) => {
 

--- a/backend/migrations/20250823000000-add-strava-fields.js
+++ b/backend/migrations/20250823000000-add-strava-fields.js
@@ -1,0 +1,70 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Usersテーブルにストラヴァフィールドを追加
+    await queryInterface.addColumn('users', 'strava_athlete_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      unique: true
+    });
+    
+    await queryInterface.addColumn('users', 'strava_access_token', {
+      type: Sequelize.TEXT,
+      allowNull: true
+    });
+    
+    await queryInterface.addColumn('users', 'strava_refresh_token', {
+      type: Sequelize.TEXT,
+      allowNull: true
+    });
+    
+    await queryInterface.addColumn('users', 'strava_token_expires_at', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+    
+    await queryInterface.addColumn('users', 'strava_last_sync', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+
+    // Workoutsテーブルに外部データ識別フィールドを追加
+    await queryInterface.addColumn('workouts', 'external_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      unique: true
+    });
+    
+    await queryInterface.addColumn('workouts', 'source', {
+      type: Sequelize.ENUM('manual', 'strava'),
+      allowNull: false,
+      defaultValue: 'manual'
+    });
+    
+    await queryInterface.addColumn('workouts', 'raw_data', {
+      type: Sequelize.JSON,
+      allowNull: true
+    });
+    
+    await queryInterface.addColumn('workouts', 'synced_at', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // Usersテーブルからストラヴァフィールドを削除
+    await queryInterface.removeColumn('users', 'strava_athlete_id');
+    await queryInterface.removeColumn('users', 'strava_access_token');
+    await queryInterface.removeColumn('users', 'strava_refresh_token');
+    await queryInterface.removeColumn('users', 'strava_token_expires_at');
+    await queryInterface.removeColumn('users', 'strava_last_sync');
+
+    // Workoutsテーブルから外部データフィールドを削除
+    await queryInterface.removeColumn('workouts', 'external_id');
+    await queryInterface.removeColumn('workouts', 'source');
+    await queryInterface.removeColumn('workouts', 'raw_data');
+    await queryInterface.removeColumn('workouts', 'synced_at');
+  }
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -21,6 +21,27 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    strava_athlete_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      unique: true,
+    },
+    strava_access_token: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    strava_refresh_token: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    strava_token_expires_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    strava_last_sync: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   }, {
     tableName: 'users',
     timestamps: false,

--- a/backend/models/Workout.js
+++ b/backend/models/Workout.js
@@ -53,6 +53,24 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
+    external_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      unique: true,
+    },
+    source: {
+      type: DataTypes.ENUM('manual', 'strava'),
+      allowNull: false,
+      defaultValue: 'manual',
+    },
+    raw_data: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    synced_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
 
   }, {
     tableName: 'workouts',

--- a/backend/routes/stravaRoutes.js
+++ b/backend/routes/stravaRoutes.js
@@ -1,0 +1,119 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../middleware/checkJWT');
+const stravaService = require('../services/stravaService');
+const { User } = require('../models');
+
+// メモリベースのstateストレージ（本番では Redis等を使用推奨）
+const stateStorage = new Map();
+
+// OAuth認証開始
+router.post('/auth', authMiddleware, async (req, res) => {
+  try {
+    const state = stravaService.generateState();
+    const authUrl = stravaService.getAuthUrl(state);
+    
+    // stateをストレージに保存（5分で期限切れ）
+    stateStorage.set(state, {
+      userId: req.user.id,
+      timestamp: Date.now()
+    });
+    
+    // 5分後にstateを削除
+    setTimeout(() => {
+      stateStorage.delete(state);
+    }, 5 * 60 * 1000);
+    
+    res.json({ authUrl, state });
+  } catch (error) {
+    console.error('Strava auth initiation error:', error);
+    res.status(500).json({ error: 'Failed to initiate Strava authentication' });
+  }
+});
+
+// OAuth認証コールバック
+router.get('/callback', async (req, res) => {
+  try {
+    const { code, state, scope } = req.query;
+    
+    if (!code || !state) {
+      return res.status(400).json({ error: 'Missing required parameters' });
+    }
+    
+    // state検証
+    const stateData = stateStorage.get(state);
+    if (!stateData) {
+      return res.status(400).json({ error: 'Invalid or expired state parameter' });
+    }
+    
+    // stateを削除（使い捨て）
+    stateStorage.delete(state);
+    
+    // アクセストークンを取得
+    const tokenData = await stravaService.exchangeCodeForToken(code);
+    
+    // ユーザー情報を更新
+    await User.update({
+      strava_athlete_id: tokenData.athlete.id.toString(),
+      strava_access_token: stravaService.encryptToken(tokenData.access_token),
+      strava_refresh_token: stravaService.encryptToken(tokenData.refresh_token),
+      strava_token_expires_at: new Date(tokenData.expires_at * 1000)
+    }, { 
+      where: { id: stateData.userId } 
+    });
+
+    // フロントエンドにリダイレクト
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+    res.redirect(`${frontendUrl}/dashboard?strava=connected`);
+    
+  } catch (error) {
+    console.error('Strava callback error:', error);
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+    res.redirect(`${frontendUrl}/dashboard?strava=error&message=${encodeURIComponent(error.message)}`);
+  }
+});
+
+// Strava連携ステータス確認
+router.get('/status', authMiddleware, async (req, res) => {
+  try {
+    const user = await User.findByPk(req.user.id);
+    
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const connected = !!(user.strava_athlete_id && user.strava_access_token);
+    
+    res.json({
+      connected,
+      athlete_id: user.strava_athlete_id,
+      last_sync: user.strava_last_sync,
+      activities_count: 0 // TODO: 実際の同期済みアクティビティ数を取得
+    });
+  } catch (error) {
+    console.error('Strava status check error:', error);
+    res.status(500).json({ error: 'Failed to check Strava status' });
+  }
+});
+
+// Strava連携解除
+router.delete('/disconnect', authMiddleware, async (req, res) => {
+  try {
+    await User.update({
+      strava_athlete_id: null,
+      strava_access_token: null,
+      strava_refresh_token: null,
+      strava_token_expires_at: null,
+      strava_last_sync: null
+    }, { 
+      where: { id: req.user.id } 
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Strava disconnect error:', error);
+    res.status(500).json({ error: 'Failed to disconnect Strava' });
+  }
+});
+
+module.exports = router;

--- a/backend/services/stravaService.js
+++ b/backend/services/stravaService.js
@@ -1,0 +1,136 @@
+const axios = require('axios');
+const crypto = require('crypto');
+
+class StravaService {
+  constructor() {
+    this.clientId = process.env.STRAVA_CLIENT_ID;
+    this.clientSecret = process.env.STRAVA_CLIENT_SECRET;
+    this.redirectUri = process.env.STRAVA_REDIRECT_URI;
+    this.baseURL = 'https://www.strava.com/api/v3';
+    this.authURL = 'https://www.strava.com/oauth';
+  }
+
+  // OAuth認証URL生成
+  getAuthUrl(state) {
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      response_type: 'code',
+      redirect_uri: this.redirectUri,
+      approval_prompt: 'force',
+      scope: 'read,activity:read_all',
+      state
+    });
+    
+    return `${this.authURL}/authorize?${params}`;
+  }
+
+  // 認証コードをアクセストークンに交換
+  async exchangeCodeForToken(code) {
+    try {
+      const response = await axios.post(`${this.authURL}/token`, {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+        grant_type: 'authorization_code'
+      });
+
+      return response.data;
+    } catch (error) {
+      throw new Error(`Token exchange failed: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  // リフレッシュトークンでアクセストークンを更新
+  async refreshAccessToken(refreshToken) {
+    try {
+      const response = await axios.post(`${this.authURL}/token`, {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token'
+      });
+
+      return response.data;
+    } catch (error) {
+      throw new Error(`Token refresh failed: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  // アクティビティ取得
+  async getActivities(accessToken, page = 1, perPage = 30, after = null) {
+    try {
+      const params = {
+        page,
+        per_page: perPage
+      };
+      
+      if (after) {
+        params.after = Math.floor(after.getTime() / 1000);
+      }
+
+      const response = await axios.get(`${this.baseURL}/athlete/activities`, {
+        headers: {
+          'Authorization': `Bearer ${accessToken}`
+        },
+        params
+      });
+
+      return response.data;
+    } catch (error) {
+      if (error.response?.status === 401) {
+        throw new Error('Access token expired');
+      }
+      throw new Error(`Failed to fetch activities: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  // トークン暗号化
+  encryptToken(token) {
+    if (!token) return null;
+    const cipher = crypto.createCipher('aes-256-cbc', process.env.ENCRYPTION_KEY);
+    let encrypted = cipher.update(token, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    return encrypted;
+  }
+
+  // トークン復号化
+  decryptToken(encryptedToken) {
+    if (!encryptedToken) return null;
+    const decipher = crypto.createDecipher('aes-256-cbc', process.env.ENCRYPTION_KEY);
+    let decrypted = decipher.update(encryptedToken, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
+
+  // state生成（CSRF対策）
+  generateState() {
+    return crypto.randomBytes(32).toString('hex');
+  }
+
+  // StravaアクティビティをWorkout形式に変換
+  mapStravaToWorkout(stravaActivity, userId) {
+    const typeMapping = {
+      'Run': 'ランニング',
+      'Ride': 'サイクリング', 
+      'Swim': '水泳',
+      'Walk': 'ウォーキング',
+      'Hike': 'ハイキング',
+      'WeightTraining': 'ウェイトトレーニング'
+    };
+
+    return {
+      userID: userId,
+      external_id: stravaActivity.id.toString(),
+      source: 'strava',
+      date: stravaActivity.start_date.split('T')[0],
+      exercise: stravaActivity.name,
+      exerciseType: typeMapping[stravaActivity.sport_type] || 'その他',
+      distance: stravaActivity.distance ? stravaActivity.distance / 1000 : null, // m→km
+      duration: stravaActivity.moving_time || stravaActivity.elapsed_time, // seconds
+      raw_data: stravaActivity,
+      synced_at: new Date()
+    };
+  }
+}
+
+module.exports = new StravaService();


### PR DESCRIPTION
  - DBマイグレーションでusers/workoutsテーブルにStravaフィールド追加
  - StravaServiceクラスでOAuthトークン管理機能を実装
  - Strava APIルート（/auth, /callback, /status, /disconnect）を追加
  - AES-256-CBCによるトークン暗号化/復号化を統合
  - stateパラメータによるCSRF攻撃対策を実装
  - アクティビティデータソース識別（手動/strava）機能を追加