### PR TITLE
test(login): Login.jsxのテスト実装とMUI対応

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -116,6 +116,7 @@ const Login = () => {
               render={({ field }) => (
                 <TextField
                 {...field}
+                data-testid="email-field"
                 margin="normal"
                 required
                 fullWidth
@@ -147,6 +148,7 @@ const Login = () => {
               render={({ field }) => (
                 <TextField
                 {...field}
+                data-testid="password-field"
                 margin="normal"
                 required
                 fullWidth

--- a/frontend/src/components/__tests__/Login.test.tsx
+++ b/frontend/src/components/__tests__/Login.test.tsx
@@ -1,0 +1,41 @@
+
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest'; // vi を追加
+import Login from '../Login';
+
+const mockLogin = vi.fn();
+
+vi.mock('../Hook', () => ({
+  useAuth: () => ({
+    login: mockLogin,
+  }),
+}));
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <BrowserRouter>{children}</BrowserRouter>
+);
+
+
+describe('Login Component', () => {
+  
+
+  it('ログインページが正しく表示される', () => {
+
+    render(
+      <TestWrapper>
+        <Login />
+      </TestWrapper>
+    );
+
+    expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '新規アカウント作成' })).toBeInTheDocument();
+    
+    expect(screen.getByText('FitStarへようこそ')).toBeInTheDocument();
+    
+    expect(screen.getByTestId('email-field')).toBeInTheDocument();
+    expect(screen.getByTestId('password-field')).toBeInTheDocument();
+  });
+
+});


### PR DESCRIPTION
- Login.jsxの基本表示テストを実装
- MUI + React Hook Form環境でのセレクタ問題を解決
- data-testid属性を追加してテスト要素を確実に特定
- useAuth()モックとTestWrapperでテスト環境を構築
- Register.jsxと同じdata-testid戦略を採用

🤖 Generated with [Claude Code](https://claude.ai/code)