### PR TITLE
feat(#131): WorkoutHistoryTable Phase 2 C1テスト実装と重複ヘッダー修正

### DIFF
--- a/frontend/src/components/WorkoutHistoryTable.jsx
+++ b/frontend/src/components/WorkoutHistoryTable.jsx
@@ -145,50 +145,7 @@ const WorkoutHistoryTable = ({
           </TableHead>
 
             {/* 第2段階: データセル */}
-            <TableHead>
-              {/* 第1段階: 種目名のヘッダー */}
-              <TableRow sx={{ bgcolor: theme.palette.grey[50] }}>
-                <TableCell sx={{ fontWeight: 'bold', borderRight: `1px solid ${theme.palette.divider}`, minWidth: 100 }}>
-                  日付
-                </TableCell>
-                
-                {workoutConfig.exercises.map(exerciseName => {
-                  const isCardio = isCardioExercise(exerciseName);
-                  const colSpan = isCardio ? 2 : workoutConfig.maxSets;
-                  return (
-                  <TableCell
-                  key={exerciseName}
-                  colSpan={colSpan}
-                  align="center"
-                  sx={{ 
-                    fontWeight: 'bold',
-                    borderRight: `1px solid ${theme.palette.divider}`,
-                    minWidth: isCardio ? 160 : colSpan * 80,
-                  }}
-                >
-                  {exerciseName}
-                  {isCardio && (
-                    <Typography variant="caption" display="block" color="text.secondary">
-                      (距離・時間)
-                      </Typography>
-                    )}
-                    </TableCell>
-                    );
-                    })}
-                    
-                    {/* 合計列のヘッダー */}
-                    {workoutConfig.displayColumns?.includes('totalReps') && (
-                      <TableCell align="center" sx={{ fontWeight: 'bold', borderRight: `1px solid ${theme.palette.divider}` }}>
-                        合計回数
-                        </TableCell>
-                      )}
-                      {workoutConfig.displayColumns?.includes('totalTime') && (
-                        <TableCell align="center" sx={{ fontWeight: 'bold' }}>
-                          合計時間
-                        </TableCell>
-                      )}
-                    </TableRow>
-                    
+            <TableHead>   
                     {/* 第2段階: セット/詳細のヘッダー */}
                     <TableRow sx={{ bgcolor: theme.palette.grey[100] }}>
                       <TableCell sx={{ borderRight: `1px solid ${theme.palette.divider}` }} />

--- a/frontend/src/components/__tests__/WorkoutHistoryTable.test.jsx
+++ b/frontend/src/components/__tests__/WorkoutHistoryTable.test.jsx
@@ -1,8 +1,7 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { render, screen } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';  
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import WorkoutHistoryTable from '../WorkoutHistoryTable';
-import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme();
 const TestWrapper = ({ children }) => (
@@ -13,65 +12,64 @@ const mockIsCardioExercise = vi.fn();
 const mockIsStrengthExercise = vi.fn();
 
 const testDataStrategy = {
-
   completeWorkout: {
     date: '2024-01-15',
     exercises: {
-      'ランニング': { distance: 5.0, duration: 30 },
-      'ベンチプレス': { set1: '10', set2: '8', set3: '10' },
-      'スクワット': { set1: '12', set2: '10', set3: '12' }
+      ランニング: { distance: 5.0, duration: 30 },
+      ベンチプレス: { set1: '10', set2: '8', set3: '10' },
+      スクワット: { set1: '12', set2: '10', set3: '12' },
     },
     totalReps: 62,
-    totalTime: 45
+    totalTime: 45,
   },
-  
+
   partialWorkout: {
     date: '2024-01-10',
     exercises: {
-      'ランニング': { distance: 3.2, duration: 20 }, 
-      'ベンチプレス': { set1: '15' }, 
-      'スクワット': {} // その日はスキップ（体調・時間等）
+      ランニング: { distance: 3.2, duration: 20 },
+      ベンチプレス: { set1: '15' },
+      スクワット: {}, // その日はスキップ（体調・時間等）
     },
     totalReps: 15,
-    totalTime: 20
+    totalTime: 20,
   },
 
   inconsistentDataWorkout: {
     date: '2024-01-08',
     exercises: {
-      'ランニング': { distance: 2.5 }, 
-      'ベンチプレス': { set1: '12', set3: '10' }, 
-      'スクワット': { set2: '15' } // set1なしでset2のみ（珍しいが可能）
-    }
+      ランニング: { distance: 2.5 },
+      ベンチプレス: { set1: '12', set3: '10' },
+      スクワット: { set2: '15' }, // set1なしでset2のみ（珍しいが可能）
+    },
   },
 
   configVariations: {
-    maxSets3: { 
-      exercises: ['ベンチプレス'], 
-      maxSets: 3, 
-      displayColumns: ['totalReps'] 
+    maxSets3: {
+      exercises: ['ベンチプレス'],
+      maxSets: 3,
+      displayColumns: ['totalReps'],
     },
-    maxSets5: { 
-      exercises: ['ベンチプレス'], 
-      maxSets: 5, 
-      displayColumns: undefined 
+    maxSets5: {
+      exercises: ['ベンチプレス'],
+      maxSets: 5,
+      displayColumns: undefined,
     },
-    mixed: { 
-      exercises: ['ランニング', 'ベンチプレス'], 
-      maxSets: 3, 
-      displayColumns: ['totalReps', 'totalTime'] 
-    }
-  }
+    mixed: {
+      exercises: ['ランニング', 'ベンチプレス'],
+      maxSets: 3,
+      displayColumns: ['totalReps', 'totalTime'],
+    },
+  },
 };
 
 describe('WorkoutHistoryTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsCardioExercise.mockImplementation((exercise) => 
-      exercise === 'ランニング' || exercise === 'サイクリング'
+    mockIsCardioExercise.mockImplementation(
+      exercise => exercise === 'ランニング' || exercise === 'サイクリング'
     );
-    mockIsStrengthExercise.mockImplementation((exercise) => 
-      exercise === 'ベンチプレス' || exercise === 'スクワット'
+    mockIsStrengthExercise.mockImplementation(
+      exercise => exercise === 'ベンチプレス' || exercise === 'スクワット'
     );
   });
 
@@ -79,18 +77,65 @@ describe('WorkoutHistoryTable', () => {
     console.log('Mock Test Results:');
     console.log('ランニング → Cardio:', mockIsCardioExercise('ランニング'));
     console.log('ベンチプレス → Cardio:', mockIsCardioExercise('ベンチプレス'));
-    console.log('ベンチプレス → Strength:', mockIsStrengthExercise('ベンチプレス'));
-    
+    console.log(
+      'ベンチプレス → Strength:',
+      mockIsStrengthExercise('ベンチプレス')
+    );
+
     render(
       <TestWrapper>
-        <WorkoutHistoryTable workouts={[testDataStrategy.completeWorkout]} workoutConfig={testDataStrategy.configVariations.maxSets3} loading={false} isCardioExercise={mockIsCardioExercise} isStrengthExercise={mockIsStrengthExercise} />
+        <WorkoutHistoryTable
+          workouts={[testDataStrategy.completeWorkout]}
+          workoutConfig={testDataStrategy.configVariations.maxSets3}
+          loading={false}
+          isCardioExercise={mockIsCardioExercise}
+          isStrengthExercise={mockIsStrengthExercise}
+        />
       </TestWrapper>
     );
-    
+
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByText('詳細履歴')).toBeInTheDocument();
-    
+
     expect(mockIsCardioExercise).toHaveBeenCalledWith('ベンチプレス');
     expect(mockIsStrengthExercise).toHaveBeenCalledWith('ベンチプレス');
+  });
+
+  describe('🔄 動的colSpan計算エンジン', () => {
+    it('🔴 Cardio種目でcolSpan=2が正確に設定される', () => {
+      mockIsCardioExercise.mockImplementation(ex => ex === 'ランニング');
+      mockIsStrengthExercise.mockImplementation(() => false);
+
+      const config = {
+        exercises: ['ランニング'],
+        maxSets: 3,
+        displayColumns: [],
+      };
+
+      render(
+        <TestWrapper>
+          <WorkoutHistoryTable
+            workouts={[testDataStrategy.completeWorkout]}
+            workoutConfig={config}
+            loading={false}
+            isCardioExercise={mockIsCardioExercise}
+            isStrengthExercise={mockIsStrengthExercise}
+          />
+        </TestWrapper>
+      );
+
+      console.log('Header Elements:');
+      screen.getAllByRole('columnheader').forEach(header => {
+        console.log({
+          name: header.textContent,
+          colspan: header.getAttribute('colspan'),
+          html: header.outerHTML,
+        });
+      });
+
+      expect(
+        screen.getByRole('columnheader', { name: 'ランニング (距離・時間)' })
+      ).toHaveAttribute('colSpan', '2');
+    });
   });
 });


### PR DESCRIPTION
Phase 2 Critical Tests実装:
- 動的colSpan計算エンジンテスト追加
- Cardio種目でcolSpan=2の正確な検証
- getByRole('columnheader')による適切なセレクタ実装
- console.logによるDOM構造デバッグ

WorkoutHistoryTable.jsx修正:
- 重複していた第1層ヘッダー削除 (lines 148-190)
- テーブル構造の簡素化とレンダリング最適化


🤖 Generated with [Claude Code](https://claude.ai/code)