### PR TITLE
fix(strava): Stravaデータのexercise/exerciseTypeフィールドを標準化

### DIFF
--- a/backend/services/stravaService.js
+++ b/backend/services/stravaService.js
@@ -132,10 +132,18 @@ class StravaService {
   }
 
   mapStravaToWorkout(stravaActivity, userId) {
-    const typeMapping = {
+    const exerciseNameMapping = {
       'Run': 'ランニング',
       'Walk': 'ウォーキング',
-      'WeightTraining': 'ウェイトトレーニング'
+    }
+
+    const exerciseTypeMapping = {
+      'Run': 'cardio',
+      'Walk': 'cardio',
+      'Ride': 'cardio',
+      'Swim': 'cardio',
+      'WeightTraining': 'strength',
+      'Workout': 'strength',
     }
 
     return {
@@ -143,8 +151,8 @@ class StravaService {
       external_id: stravaActivity.id.toString(),
       source: 'strava',
       date: stravaActivity.start_date.split('T')[0],
-      exercise: stravaActivity.name,
-      exerciseType: typeMapping[stravaActivity.sport_type] || '不明',
+      exercise: exerciseNameMapping[stravaActivity.sport_type] || stravaActivity.name,
+      exerciseType: exerciseTypeMapping[stravaActivity.sport_type] || 'cardio',
       distance: stravaActivity.distance ? stravaActivity.distance / 1000 : null,
       duration: stravaActivity.moving_time || stravaActivity.elapsed_time,
       raw_data: stravaActivity,  

--- a/frontend/src/hooks/useWorkoutConfig.js
+++ b/frontend/src/hooks/useWorkoutConfig.js
@@ -31,6 +31,7 @@ const useWorkoutConfig = () => {
       exerciseData.nameMapping.pushup || 'プッシュアップ',
       exerciseData.nameMapping.squat || 'スクワット',
       exerciseData.nameMapping.walking || 'ウォーキング',
+      exerciseData.nameMapping.running || 'ランニング',
       exerciseData.nameMapping.jumping_lunge || 'ジャンプランジ',
       exerciseData.nameMapping.jump_squat || 'ジャンプスクワット',
     ],


### PR DESCRIPTION
  - exerciseフィールドをStravaのアクティビティ名から開発アプリ正規表現へ修正
  - exerciseTypeをアプリ仕様のcardio/strength形式に統一
  - 各種Strava運動タイプに対応したマッピングを追加
  - 未対応の運動タイプはデフォルトでcardioに設定