### PR TITLE
  feat(ui): ワークアウト履歴の表示形式を改善

### DIFF
--- a/frontend/src/components/WorkoutHistoryTable.jsx
+++ b/frontend/src/components/WorkoutHistoryTable.jsx
@@ -1,5 +1,6 @@
 import { Box, CircularProgress, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, useTheme } from '@mui/material';
 import React from 'react';
+import { formatDuration, formatDistance } from '../utils/formatters';
 
 const WorkoutHistoryTable = ({
   workouts = [],
@@ -159,7 +160,7 @@ const WorkoutHistoryTable = ({
                               距離(km)
                               </TableCell>
                               <TableCell align="center" sx={{ fontSize: '0.75rem', color: theme.palette.text.secondary, borderRight: `1px solid ${theme.palette.divider}`, py: 1 }}>
-                                時間(分)
+                                時間
                               </TableCell>
                             </>
                           ) : (
@@ -216,10 +217,10 @@ const WorkoutHistoryTable = ({
                       {isCardio ? (
                         <>
                         <TableCell align="center" sx={{ borderRight: `1px solid ${theme.palette.divider}` }}>
-                          {exercise?.distance ? `${exercise.distance}km` : '-'}
+                          {formatDistance(exercise?.distance)}
                         </TableCell>
                         <TableCell align="center" sx={{ borderRight: `1px solid ${theme.palette.divider}` }}>
-                          {exercise?.duration ? `${exercise.duration}分` : '-'}
+                          {formatDuration(exercise?.duration)}
                         </TableCell>
                         </>
                       ) : (

--- a/frontend/src/services/TransformWorkoutData.js
+++ b/frontend/src/services/TransformWorkoutData.js
@@ -12,6 +12,7 @@ const transformWorkoutData = apiData => {
     if (!acc[dateKey]) {
       acc[dateKey] = {
         date: dateKey,
+        dateForSort: workout.date,
         exercises: {},
         totalReps: 0,
         totalTime: 0,
@@ -38,7 +39,7 @@ const transformWorkoutData = apiData => {
     return acc;
   }, {});
 
-  return Object.values(groupedByDate);
+  return Object.values(groupedByDate).sort((a, b) => new Date(b.dateForSort) - new Date(a.dateForSort));
 };
 
 export default transformWorkoutData;

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,20 @@
+export const formatDuration = seconds => {
+  if (!seconds || seconds === 0) {
+    return '-';
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  const paddedSeconds = remainingSeconds.toString().padStart(2, '0');
+
+  return `${minutes}m${paddedSeconds}s`;
+};
+
+export const formatDistance = distance => {
+  if (!distance && distance !== 0) {
+    return '-';
+  }
+
+  // 小数点第1位で表示
+  return `${distance.toFixed(2)}km`;
+};


### PR DESCRIPTION
- UI表示用フォーマット関数作成
- 時間表示を15m04s形式にフォーマット（formatDuration関数追加）
- 距離表示を小数点第2位まで統一（formatDistance関数追加）
- ワークアウト履歴を日付降順でソート（新→旧順）
- WorkoutHistoryTableでフォーマット関数を適用