### PR TITLE
fix(oauth): OAuth認証フローの設計修正とCORS設定強化

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,18 +1,20 @@
 const express = require('express');
 const app = express();
 const cors = require('cors');
-const helmet = require('helmet'); // セキュリティヘッダー強化
+const helmet = require('helmet');
 const authRouter = require("./routes/authRoutes");
 const workouts = require('./routes/workouts');
 const stravaRoutes = require('./routes/stravaRoutes');
 
-// 環境に応じた動的なCORS設定の実装
+
 const getCorsConfig = () => {
   const currentEnv = process.env.NODE_ENV || 'development';
   const isProduction = currentEnv === 'production';
   if (isProduction) {
     return {
-      origin: process.env.CORS_ORIGIN_PROD,
+      origin: process.env.CORS_ORIGIN_PROD || 'https://fitstart-frontend.vercel.app',
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization'],
       credentials: true,
     };
   } else {
@@ -22,6 +24,8 @@ const getCorsConfig = () => {
         'http://localhost:3000',
         'http://127.0.0.1:3000'
       ],
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization'],
       credentials: true,
     };
   }

--- a/backend/routes/stravaRoutes.js
+++ b/backend/routes/stravaRoutes.js
@@ -7,7 +7,7 @@ const { User } = require('../models');
 
 const stateStorage = new Map();
 
-router.get('/auth', authMiddleware, async (req, res) => {
+router.post('/auth', authMiddleware, async (req, res) => {
   try {
     const state = stravaService.generateState();
     const authUrl = stravaService.getAuthUrl(state);
@@ -19,8 +19,8 @@ router.get('/auth', authMiddleware, async (req, res) => {
       stateStorage.delete(state);
     }, 5 * 60 * 1000);
 
-    // 本番・開発環境共に直接リダイレクト
-    res.redirect(authUrl);
+    // JSON形式でauthUrlを返却（CORS対応）
+    res.json({ authUrl });
 
   } catch (error) {
     console.error('Strava auth initiation error:', error);

--- a/frontend/src/components/strava/StravaConnect.jsx
+++ b/frontend/src/components/strava/StravaConnect.jsx
@@ -74,14 +74,18 @@ const StravaConnect = ({ onStatusChange }) => {
         error: null
        }));
       
-      const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-      window.location.href = `${API_BASE_URL}/api/strava/auth`;
+      const response = await apiClient.post('/api/strava/auth');
+      if (!response) {
+        throw new Error('Strava認証URLの取得に失敗しました');
+      }
+      const authUrl = response.data.authUrl;
+      window.location.href = authUrl;
       
     } catch (error) {
       setConnectionState(prev =>({
         ...prev,
         loading: false,
-        error: error.message || 'Strava接続に失敗しました'
+        error: error.response?.data?.error || error.message || 'Strava接続に失敗しました'
       }));
     }
   };


### PR DESCRIPTION
GET→POSTリダイレクトで発生した認証エラーと404問題を解決
- POST /api/strava/auth に回帰（セキュアな認証付きエンドポイント）
- CORS設定に詳細なheaders/methods指定を追加
- フロントエンドでAPI呼び出し→URL取得→リダイレクトフローを復元
- 本番環境フォールバック値でデプロイ時の設定不備に対応

🤖 Generated with [Claude Code](https://claude.ai/code)