### PR TITLE
fix(test):WorkoutHistoryTableコンポーネントヘッダー修正

### DIFF
--- a/frontend/src/components/WorkoutHistoryTable.jsx
+++ b/frontend/src/components/WorkoutHistoryTable.jsx
@@ -157,7 +157,7 @@ const WorkoutHistoryTable = ({
                               距離(km)
                               </TableCell>
                               <TableCell align="center" sx={{ fontSize: '0.75rem', color: theme.palette.text.secondary, borderRight: `1px solid ${theme.palette.divider}`, py: 1 }}>
-                                時間
+                                時間(分)
                               </TableCell>
                             </>
                           ) : (


### PR DESCRIPTION
WorkoutHistoryTable.jsxのcardio系のcellのテキスト修正　修正前：時間→ 修正後:時間(分) 
UIを時間(km)と統一