### PR TITLE
fix(test): StravaSync コンポーネントのテストタイムアウトエラーを修正

### DIFF
--- a/frontend/src/components/strava/StravaSync.jsx
+++ b/frontend/src/components/strava/StravaSync.jsx
@@ -140,7 +140,7 @@ const StravaSync = () => {
         </Collapse>
         
         {/* 成功表示 */}
-        <Collapse in={syncState.status === 'completed' && syncState.result}>
+        <Collapse in={syncState.status === 'completed' && !!syncState.result}>
           <Alert 
             severity="success" 
             icon={<CheckCircleIcon />}
@@ -170,7 +170,7 @@ const StravaSync = () => {
         </Collapse>
         
         {/* エラー表示 */}
-        <Collapse in={syncState.status === 'failed' && syncState.error}>
+        <Collapse in={syncState.status === 'failed' && !!syncState.error}>
           <Alert 
             severity="error" 
             icon={<ErrorIcon />}

--- a/frontend/src/components/strava/__tests__/StravaSync.test.jsx
+++ b/frontend/src/components/strava/__tests__/StravaSync.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { server } from '../../../test/mocks/server';
 import { stravaSyncErrorHandlers } from '../../../test/mocks/handlers/strava';
@@ -8,66 +8,76 @@ import { TestWrapper } from './testUtils';
 describe('StravaSyncエラーハンドリングテスト', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers(); // タイマーテストのための偽タイマー設定
+    server.resetHandlers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    vi.clearAllTimers();
   });
 
   it('M2-2. 同期処理失敗時のエラー表示', async () => {
-    // ステップ1: MSWで同期エラーハンドラーを設定
     server.use(...stravaSyncErrorHandlers);
 
-    // ステップ2: コンポーネントをレンダリング
     render(
       <TestWrapper>
         <StravaSync />
       </TestWrapper>
     );
 
-    // ステップ3: 初期状態を確認（アイドル状態）
-    await waitFor(
-      () => {
-        expect(screen.getByText('データを同期')).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
+    await waitFor(() => {
+      expect(screen.getByText('データを同期')).toBeInTheDocument();
+    });
 
-    // ステップ4: 同期ボタンクリックでAPI呼び出し実行
     const syncButton = screen.getByRole('button', { name: /データを同期/ });
     expect(syncButton).toBeInTheDocument();
     expect(syncButton).not.toBeDisabled();
-    fireEvent.click(syncButton);
 
-    // ステップ5: エラー表示を検証
+
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+
+
     await waitFor(
       () => {
-        // エラーアラートの表示確認
-        const errorAlert = screen.getByRole('alert');
-        expect(errorAlert).toBeInTheDocument();
+
+        const alerts = screen.getAllByRole('alert');
+        const errorAlert = alerts.find(alert =>
+          alert.classList.contains('MuiAlert-colorError')
+        );
+        expect(errorAlert).toBeDefined();
         expect(errorAlert).toHaveTextContent('Sync failed');
-        
-        // 「閉じる」ボタンの表示確認
+
         const closeButton = screen.getByRole('button', { name: /閉じる/ });
         expect(closeButton).toBeInTheDocument();
       },
       { timeout: 3000 }
     );
 
-    // ステップ6: 5秒後の自動非表示を確認
-    // 5秒経過をシミュレート
-    vi.advanceTimersByTime(5000);
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
 
     await waitFor(() => {
-      // エラーアラートが非表示になることを確認
-      expect(screen.queryByText('Sync failed')).not.toBeInTheDocument();
-      
-      // アイドル状態に戻ることを確認
+
+      const alerts = screen.queryAllByRole('alert');
+      const errorAlert = alerts.find(alert =>
+        alert.classList.contains('MuiAlert-colorError')
+      );
+      expect(errorAlert).toBeUndefined();
+
       const idleButton = screen.getByRole('button', { name: /データを同期/ });
       expect(idleButton).toBeInTheDocument();
       expect(idleButton).not.toBeDisabled();
+
+      const infoAlerts = screen.queryAllByRole('alert');
+      const infoAlert = infoAlerts.find(alert =>
+        alert.classList.contains('MuiAlert-colorInfo')
+      );
+      expect(infoAlert).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
  - FakeTimersの設定を改善（shouldAdvanceTime: true）して非同期処理との競合を解消
  - React Testing Libraryのactパターンを適用して状態更新を正しく処理
  - MSWハンドラーの競合を防ぐためserver.resetHandlers()を追加
  - Collapseコンポーネントのin属性に!!演算子を使用してboolean型を保証