### PR TITLE
feat(#180): 月別統計機能のMVP実装 - UIコンポーネント追加

### DIFF
--- a/frontend/src/components/statistics/MonthSelector.jsx
+++ b/frontend/src/components/statistics/MonthSelector.jsx
@@ -1,0 +1,92 @@
+import { Box, IconButton, Typography } from '@mui/material';
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+} from '@mui/icons-material';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ja';
+
+// 日本語ロケールを設定
+dayjs.locale('ja');
+
+const MonthSelector = ({ currentMonth, onMonthChange }) => {
+  const current = dayjs(currentMonth);
+  const now = dayjs();
+
+  // 前月へ移動
+  const handlePreviousMonth = () => {
+    const previousMonth = current.subtract(1, 'month').toDate();
+    onMonthChange(previousMonth);
+  };
+
+  // 次月へ移動
+  const handleNextMonth = () => {
+    const nextMonth = current.add(1, 'month').toDate();
+    onMonthChange(nextMonth);
+  };
+
+  // 未来の月は選択不可
+  const isNextDisabled = current.year() >= now.year() &&
+                         current.month() >= now.month();
+
+  // 月の表示フォーマット（例: "2025年1月"）
+  const monthDisplay = current.format('YYYY年M月');
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        my: 2,
+      }}
+    >
+      <IconButton
+        onClick={handlePreviousMonth}
+        aria-label="前月へ"
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          '&:hover': {
+            bgcolor: 'action.hover',
+          },
+        }}
+      >
+        <ChevronLeftIcon />
+      </IconButton>
+
+      <Typography
+        variant="h6"
+        component="h2"
+        sx={{
+          minWidth: 120,
+          textAlign: 'center',
+          fontWeight: 600,
+        }}
+      >
+        {monthDisplay}
+      </Typography>
+
+      <IconButton
+        onClick={handleNextMonth}
+        disabled={isNextDisabled}
+        aria-label="次月へ"
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          '&:hover': {
+            bgcolor: 'action.hover',
+          },
+          '&.Mui-disabled': {
+            borderColor: 'action.disabledBackground',
+          },
+        }}
+      >
+        <ChevronRightIcon />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default MonthSelector;

--- a/frontend/src/components/statistics/MonthlySummaryCard.jsx
+++ b/frontend/src/components/statistics/MonthlySummaryCard.jsx
@@ -1,0 +1,179 @@
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  Divider,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import {
+  CalendarToday as CalendarIcon,
+  FitnessCenter as FitnessIcon,
+  DirectionsRun as RunIcon
+} from '@mui/icons-material';
+
+const Row = ({
+  icon: Icon,
+  label,
+  value,
+  unit,
+  lastValue,
+  changeRate,
+  highlight = 'primary',
+}) => {
+  const isPositive = typeof changeRate === 'number' ? changeRate >= 0 : null;
+
+  return (
+    <>
+      <ListItem
+        sx={{
+          px: 2,
+          py: 1.25,
+          '&:hover': { bgcolor: 'action.hover' },
+        }}
+        disableGutters
+        secondaryAction={
+          <Chip
+            size="small"
+            color={
+              typeof changeRate === 'number'
+                ? isPositive
+                  ? 'success'
+                  : 'error'
+                : 'default'
+            }
+            label={
+              typeof changeRate === 'number'
+                ? `先月より ${isPositive ? '+' : ''}${changeRate}%`
+                : `先月 ${lastValue}${unit}`
+            }
+            sx={{ fontSize: '0.72rem', height: 24 }}
+          />
+        }
+      >
+        <ListItemAvatar>
+          <Avatar
+            sx={{
+              bgcolor: `${highlight}.light`,
+              color: `${highlight}.main`,
+              width: 40,
+              height: 40,
+            }}
+          >
+            <Icon fontSize="small" />
+          </Avatar>
+        </ListItemAvatar>
+
+        <ListItemText
+          primary={
+            <Typography variant="body1" sx={{ fontWeight: 600 }}>
+              {label}
+            </Typography>
+          }
+          secondary={
+            <Box display="flex" alignItems="baseline" gap={0.5}>
+              <Typography
+                variant="h5"
+                sx={{ fontWeight: 700, color: `${highlight}.main` }}
+              >
+                {value.toLocaleString()}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {unit}
+              </Typography>
+            </Box>
+          }
+        />
+      </ListItem>
+      <Divider />
+    </>
+  );
+};
+
+const MonthlySummaryCard = ({ stats }) => {
+  // データ形式の調整（StatisticsServiceとの整合性）
+  const data = {
+    days: {
+      current: stats?.currentTotalDays || 0,
+      last: stats?.lastTotalDays || 0,
+      changeRate: stats?.daysChangeRate,
+    },
+    reps: {
+      current: stats?.currentTotalReps || 0,
+      last: stats?.lastTotalReps || 0,
+      changeRate: stats?.repsChangeRate,
+    },
+    distance: {
+      current: stats?.currentTotalDistance || 0,
+      last: stats?.lastTotalDistance || 0,
+      changeRate: stats?.distanceChangeRate,
+    },
+  };
+
+  return (
+    <Card
+      elevation={3}
+      sx={{
+        borderRadius: 3,
+        overflow: 'hidden',
+        transition: 'transform .2s ease, box-shadow .2s ease',
+        '&:hover': {
+          transform: 'translateY(-3px)',
+          boxShadow: 6
+        },
+      }}
+    >
+      <CardHeader
+        title="今月のレコード"
+        subheader="この月の合計値と先月比"
+        sx={{
+          pb: 0.5,
+          '& .MuiCardHeader-title': {
+            fontWeight: 800,
+            fontSize: '1.1rem'
+          },
+        }}
+      />
+      <CardContent sx={{ pt: 0, pb: 0 }}>
+        <List sx={{ py: 0 }}>
+          <Divider />
+          <Row
+            icon={CalendarIcon}
+            label="総ワークアウト日数"
+            value={data.days.current}
+            unit="日"
+            lastValue={data.days.last}
+            changeRate={data.days.changeRate}
+            highlight="primary"
+          />
+          <Row
+            icon={FitnessIcon}
+            label="総回数"
+            value={data.reps.current}
+            unit="回"
+            lastValue={data.reps.last}
+            changeRate={data.reps.changeRate}
+            highlight="success"
+          />
+          <Row
+            icon={RunIcon}
+            label="総距離"
+            value={data.distance.current}
+            unit="km"
+            lastValue={data.distance.last}
+            changeRate={data.distance.changeRate}
+            highlight="info"
+          />
+        </List>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MonthlySummaryCard;

--- a/frontend/src/components/statistics/StatisticsLoading.jsx
+++ b/frontend/src/components/statistics/StatisticsLoading.jsx
@@ -1,6 +1,63 @@
-import { Box, Card, CardContent, Grid, Skeleton } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardContent,
+  Grid,
+  Skeleton,
+  Divider
+} from '@mui/material';
 
-const StatisticsLoading = () => {
+const ListRowSkeleton = () => (
+  <>
+    <Box display="flex" alignItems="center" py={1.25} px={2}>
+      <Skeleton
+        variant="circular"
+        width={40}
+        height={40}
+        sx={{ mr: 2 }}
+      />
+      <Box flex={1}>
+        <Skeleton variant="text" width="40%" height={24} />
+        <Skeleton variant="text" width="25%" height={32} />
+      </Box>
+      <Skeleton variant="rounded" width={90} height={24} />
+    </Box>
+    <Divider />
+  </>
+);
+
+const StatisticsLoading = ({ variant = 'cards' }) => {
+  // 新: シングルカード表示
+  if (variant === 'single') {
+    return (
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8} lg={6}>
+          <Card elevation={3} sx={{ borderRadius: 3 }}>
+            <CardContent>
+              <Skeleton
+                variant="text"
+                width="30%"
+                height={30}
+                sx={{ mb: 0.5 }}
+              />
+              <Skeleton
+                variant="text"
+                width="45%"
+                height={20}
+                sx={{ mb: 1.5 }}
+              />
+              <Divider />
+              <ListRowSkeleton />
+              <ListRowSkeleton />
+              <ListRowSkeleton />
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  // 既存: 3枚カード表示（後方互換性）
   return (
     <Grid container spacing={3} sx={{ mb: 4 }}>
       {[1, 2, 3].map(i => (

--- a/frontend/src/components/statistics/WorkoutStatistics.jsx
+++ b/frontend/src/components/statistics/WorkoutStatistics.jsx
@@ -1,58 +1,35 @@
-import { Grid } from '@mui/material';
-import calculateWorkoutStats from '../../services/StatisticsService';
-import StatCard from './StatCard';
+import { Grid, Box } from '@mui/material';
+import { useState } from 'react';
+import { calculateMonthlyStats } from '../../services/StatisticsService';
 import StatisticsLoading from './StatisticsLoading';
-
-import {
-  CalendarToday as CalendarIcon,
-  FitnessCenter as FitnessIcon,
-  Timer as TimerIcon
-} from '@mui/icons-material';
+import MonthlySummaryCard from './MonthlySummaryCard';
+import MonthSelector from './MonthSelector';
 
 const WorkoutStatistics = ({ workouts, loading }) => {
-  const stats = calculateWorkoutStats(workouts);
+  const [selectedMonth, setSelectedMonth] = useState(new Date());
+
+  // 月別統計計算（MVP実装）
+  const stats = calculateMonthlyStats(workouts, selectedMonth);
 
   if (loading) {
-    return <StatisticsLoading />;
+    return <StatisticsLoading variant="single" />;
   }
 
   return (
-    <Grid container spacing={3}>
-      <Grid item xs={12} md={8}>
-        <Grid container spacing={3} sx={{ mb: 3 }}>
-          <StatCard
-          title="総ワークアウト日数"
-          value={stats.currentTotalDays}
-          unit="日"
-          icon={CalendarIcon}
-        change={stats.daysChangeRate}
-        lastValue={stats.lastTotalDays}
-        color="primary"
-        gridSize={{xs:6,sm:3}}
+    <Box>
+      {/* 月選択UI */}
+      <MonthSelector
+        currentMonth={selectedMonth}
+        onMonthChange={setSelectedMonth}
       />
-      <StatCard
-        title="総回数"
-        value={stats.currentTotalReps}
-        unit="回"
-        icon={FitnessIcon}
-        change={stats.repsChangeRate}
-        lastValue={stats.lastTotalReps}
-        color="success"
-        gridSize={{xs:6,sm:3}}
-      />
-      <StatCard
-        title="総時間"
-        value={stats.currentTotalTime}
-        unit="分"
-        icon={TimerIcon}
-        change={stats.timeChangeRate}
-        lastValue={stats.lastTotalTime}
-        color="info"
-        gridSize={{xs:6,sm:3}}
-      />
+
+      {/* サマリーカード */}
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8} lg={6}>
+          <MonthlySummaryCard stats={stats} />
         </Grid>
       </Grid>
-    </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
- MonthlySummaryCard: 月別統計を1枚のカードで表示（日数/回数/距離、前月比較Chip付き）
- MonthSelector: 月選択ナビゲーション（前月/次月移動、未来月無効化）
- WorkoutStatistics: StatCardからMonthlySummaryCardへ移行、月選択機能統合
- StatisticsLoading: single variant追加（後方互換性維持）
- calculateMonthlyStats関数による月別集計対応

参照ドキュメント：
[月別統計機能 - 統合ロードマップ](https://github.com/3106ksk/fittrack-app/blob/main/docs/features/monthly-statistics/design/integration-roadmap.md)