### PR TITLE
feat(workout-form): ワークアウトフォームの選択オプションを細分化

### DIFF
--- a/frontend/src/components/WorkoutForm/constants.js
+++ b/frontend/src/components/WorkoutForm/constants.js
@@ -3,19 +3,16 @@
  * UIで使用する選択肢や設定値を一元管理
  */
 
-// 距離オプション（0.0km〜10.0km、0.5km刻み）
-export const DISTANCE_OPTIONS = Array.from({ length: 11 }, (_, i) =>
-  (i * 0.5).toFixed(1)
+// 距離オプション（0.0km〜5.0km、0.1km刻み）
+export const DISTANCE_OPTIONS = Array.from({ length: 50 }, (_, i) =>
+  ((i + 1) * 0.1).toFixed(1)
 );
 
-// 時間オプション（5分〜120分、5分刻み）
-export const DURATION_OPTIONS = Array.from(
-  { length: 11 },
-  (_, i) => i * 5
-).filter(d => d > 0);
+// 時間オプション（1分〜60分、1分刻み）
+export const DURATION_OPTIONS = Array.from({ length: 60 }, (_, i) => i + 1);
 
-// レップ数オプション
-export const REPS_OPTIONS = [5, 10, 15, 20, 25, 30];
+// レップ数オプション（1〜40まで選択可能）
+export const REPS_OPTIONS = Array.from({ length: 40 }, (_, i) => i + 1);
 
 // 運動強度レベル
 export const INTENSITY_LEVELS = [


### PR DESCRIPTION
- 距離: 0.5km刻み → 0.1km刻み (0.1〜5.0km、0.0km除外)
- 時間: 5分刻み → 1分刻み (1〜60分)
- 回数: 固定6選択肢 → 1〜40の連続値

より細かい調整が可能になり、初心者から上級者まで
幅広いユーザーのニーズに対応

🤖 Generated with [Claude Code](https://claude.ai/code)