### PR TITLE
feat(#193): 週間統計機能の実装とUI改善

### DIFF
--- a/frontend/src/services/statistics/index.js
+++ b/frontend/src/services/statistics/index.js
@@ -9,6 +9,7 @@ export { calculateMonthlyStats } from './monthlyStatsCalculator';
 export { calculateChangeRate } from './changeRateCalculator';
 export { filterByMonth } from './workoutFilter';
 export { aggregateStats } from './workoutAggregator';
+export { calculateDashboardWeeklyStats } from './weeklyStatsCalculator';
 
 // デフォルトエクスポートは月別統計計算
 export { calculateMonthlyStats as default } from './monthlyStatsCalculator';

--- a/frontend/src/services/statistics/weeklyStatsCalculator.js
+++ b/frontend/src/services/statistics/weeklyStatsCalculator.js
@@ -1,7 +1,11 @@
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 
 dayjs.extend(isoWeek);
+dayjs.extend(isSameOrAfter);
+dayjs.extend(isSameOrBefore);
 
 /**
  * Dashboard用の週間統計を計算するメイン関数
@@ -79,7 +83,6 @@ export const calculateDashboardWeeklyStats = workouts => {
     let totalDistance = 0;
 
     weeklyWorkouts.forEach(workout => {
-      // cardioタイプの距離を集計
       if (workout.exerciseType === 'cardio' && workout.distance) {
         totalDistance += Number(workout.distance) || 0;
       }
@@ -89,24 +92,15 @@ export const calculateDashboardWeeklyStats = workouts => {
   };
 
   const calculateChangeRate = (currentValue, previousValue) => {
-
     if (previousValue === 0) {
       return currentValue > 0 ? 100 : 0;
     }
-
-
     const rate = ((currentValue - previousValue) / previousValue) * 100;
     return Math.round(rate * 10) / 10;
   };
 
-
   const thisWeekWorkouts = filterThisWeekWorkouts(workouts);
   const previousWeekWorkouts = filterPreviousWeekWorkouts(workouts);
-
-
-  console.log('今週のワークアウト:', thisWeekWorkouts);
-  console.log('前週のワークアウト:', previousWeekWorkouts);
-
 
   const currentStats = {
     weeklyWorkouts: thisWeekWorkouts.length,
@@ -120,13 +114,11 @@ export const calculateDashboardWeeklyStats = workouts => {
     weeklyDistance: calculateWeeklyDistance(previousWeekWorkouts)
   };
 
-
   const changeRates = {
     workouts: calculateChangeRate(currentStats.weeklyWorkouts, previousStats.weeklyWorkouts),
     reps: calculateChangeRate(currentStats.weeklyReps, previousStats.weeklyReps),
     distance: calculateChangeRate(currentStats.weeklyDistance, previousStats.weeklyDistance)
   };
-
 
   return {
     ...currentStats,


### PR DESCRIPTION
✨ 実装内容
- Dashboard用の週間統計計算機能を実装（weeklyStatsCalculator.js）
- 今週のワークアウト回数、レップス数、距離を正確に計算
- 前週との比較データと変化率（％）を算出
- ISO週（月曜開始）でのフィルタリング実装

🎨 UI改善
- 前週のデータをquickStatsに表示（「先週: X回」形式）
- 変化率をビジュアルアイコンで表示（TrendingUp/Down/Flat）
- 色分けによる視覚的フィードバック（増加:緑、減少:赤）

🔧 技術的改善
- 単一責任原則に基づくロジック分離
- StatisticsServiceへの統合

🧹 コードクリーンアップ
- デバッグ用console.logを削除
- 不要な空行とコメントを整理
- 一貫性のあるコードフォーマット

修正前の問題：
- レップス数が「totalMinutes / 60」で計算されていた（意味不明）
- 距離が「currentStreak」で表示されていた（完全に間違い）

🤖 Generated with Claude Code