### PR TITLE
feat(#199): localConfig下書きパターンを実装

### DIFF
--- a/frontend/src/components/WorkoutCustomizationDrawer.jsx
+++ b/frontend/src/components/WorkoutCustomizationDrawer.jsx
@@ -1,319 +1,218 @@
 import {
   Box,
   Button,
-  Card,
-  CardContent,
-  Chip,
-  Collapse,
+  Checkbox,
   Divider,
   Drawer,
   IconButton,
   List,
   ListItem,
-  ListItemSecondaryAction,
+  ListItemIcon,
   ListItemText,
   Slider,
   Typography,
 } from '@mui/material';
-import { useState } from 'react';
-
 import {
-  Add as AddIcon,
   Close as CloseIcon,
-  Delete as DeleteIcon,
-  ExpandMore as ExpandMoreIcon,
   FitnessCenter as FitnessCenterIcon,
   DirectionsRun as RunIcon,
 } from '@mui/icons-material';
+import { useEffect, useState } from 'react';
 
 const WorkoutCustomizationDrawer = ({
   open,
   onClose,
-  presets,
-  isCardioExercise,
-  applyPreset,
-  availableExercises,
   workoutConfig,
-  addExercise,
-  removeExercise,
-  updateMaxSets,
+  availableExercises,
+  isCardioExercise,
+  updateExercises,  // FormConfigと同一
+  updateMaxSets,     // FormConfigと同一
 }) => {
-  const [presetExpanded, setPresetExpanded] = useState(false);
+  // ローカル状態管理（FormConfigDrawerと完全同一）
+  const [localConfig, setLocalConfig] = useState({
+    exercises: workoutConfig.exercises || [],
+    maxSets: workoutConfig.maxSets || 3,
+  });
 
-  const handlePresetToggle = () => {
-    setPresetExpanded(!presetExpanded);
+  // ドロワーを開いた時の初期化（FormConfigと同一）
+  useEffect(() => {
+    if (open) {
+      setLocalConfig({
+        exercises: workoutConfig.exercises,
+        maxSets: workoutConfig.maxSets,
+      });
+    }
+  }, [open, workoutConfig.exercises, workoutConfig.maxSets]);
+
+  // 種目トグル（FormConfigと同一パターン）
+  const handleToggle = (exercise) => {
+    setLocalConfig(currentConfig => {
+      const currentIndex = currentConfig.exercises.indexOf(exercise);
+      const newExercises = [...currentConfig.exercises];
+
+      if (currentIndex === -1) {
+        // 追加
+        if (newExercises.length >= 5) {
+          alert('種目は最大5つまでです');
+          return currentConfig;
+        }
+        newExercises.push(exercise);
+      } else {
+        // 削除
+        if (newExercises.length <= 1) {
+          alert('最低1つの種目が必要です');
+          return currentConfig;
+        }
+        newExercises.splice(currentIndex, 1);
+      }
+
+      return {
+        ...currentConfig,
+        exercises: newExercises
+      };
+    });
   };
 
-  // 利用可能種目をフィルタリング（選択済み除外）
-  const availableToAdd = availableExercises.filter(
-    exercise => !workoutConfig.exercises.includes(exercise)
-  );
+  // セット数変更
+  const handleMaxSetsChange = (event, value) => {
+    setLocalConfig(prev => ({
+      ...prev,
+      maxSets: value
+    }));
+  };
+
+  // 保存（FormConfigと同一）
+  const handleSave = () => {
+    if (localConfig.exercises.length === 0) {
+      alert('最低1つの種目を選択してください');
+      return;
+    }
+    updateExercises(localConfig.exercises);
+    updateMaxSets(localConfig.maxSets);
+    onClose();
+  };
+
+  // キャンセル（FormConfigと同一）
+  const handleCancel = () => {
+    setLocalConfig({
+      exercises: workoutConfig.exercises,
+      maxSets: workoutConfig.maxSets
+    });
+    onClose();
+  };
 
   return (
     <Drawer
       anchor="right"
       open={open}
-      onClose={onClose}
+      onClose={handleCancel}
       sx={{
         '& .MuiDrawer-paper': {
-          width: { xs: '100%', sm: 700 },
+          width: { xs: '100%', sm: 400 },
           boxSizing: 'border-box',
         },
       }}
     >
-      <Box sx={{ p: 2 }}>
-        {/* ヘッダー */}
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            p: 2,
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="h6" component="h2">
-            ワークアウトカスタマイズ設定
-          </Typography>
-          <IconButton onClick={onClose} size="small">
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {/* Header */}
+        <Box sx={{ p: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="h6">ワークアウトカスタマイズ設定</Typography>
+          <IconButton onClick={handleCancel} size="small">
             <CloseIcon />
           </IconButton>
         </Box>
 
-        {/* スクロール可能コンテンツ */}
-        <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
-          {/* プリセットセクション - 折りたたみ式 */}
-          <Box sx={{ mb: 2 }}>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                cursor: 'pointer',
-                py: 1,
-                borderRadius: 1,
-                '&:hover': {
-                  bgcolor: 'action.hover',
-                },
-              }}
-              onClick={handlePresetToggle}
-            >
-              <Box>
-                <Typography variant="subtitle1">プリセット</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  よく使われる設定から選択
-                </Typography>
-              </Box>
-              <IconButton
-                size="small"
-                sx={{
-                  transform: presetExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                  transition: 'transform 0.3s ease',
-                }}
-              >
-                <ExpandMoreIcon />
-              </IconButton>
-            </Box>
+        <Divider />
 
-            <Collapse in={presetExpanded} timeout="auto" unmountOnExit>
-              <Box sx={{ mt: 2 }}>
-                {Object.entries(presets).map(([key, preset]) => {
-                  const cardioCount =
-                    preset.exercises.filter(isCardioExercise).length;
-                  const strengthCount = preset.exercises.length - cardioCount;
-                  return (
-                    <Card
-                      key={key}
-                      variant="outlined"
-                      sx={{
-                        cursor: 'pointer',
-                        mb: 1,
-                        '&:hover': {
-                          borderColor: 'primary.main',
-                          bgcolor: 'primary.50',
-                        },
-                      }}
-                      onClick={() => applyPreset(key)}
-                    >
-                      <CardContent>
-                        <Typography variant="subtitle2" gutterBottom>
-                          {preset.name}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          {preset.exercises.join(', ')}
-                        </Typography>
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            gap: 1,
-                            flexWrap: 'wrap',
-                            mt: 1,
-                          }}
-                        >
-                          {cardioCount > 0 && (
-                            <Chip
-                              icon={<RunIcon />}
-                              label={`カーディオ ${cardioCount}種目`}
-                              size="small"
-                              color="secondary"
-                            />
-                          )}
-                          {strengthCount > 0 && (
-                            <Chip
-                              icon={<FitnessCenterIcon />}
-                              label={`筋トレ ${strengthCount}種目 (${preset.maxSets}セット)`}
-                              size="small"
-                              color="primary"
-                            />
-                          )}
-                        </Box>
-                      </CardContent>
-                    </Card>
-                  );
-                })}
-              </Box>
-            </Collapse>
+        <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+          {/* 現在選択中の種目 */}
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              現在選択中の種目 ({localConfig.exercises.length}/5)
+            </Typography>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              チェックボックスで種目を選択・解除できます
+            </Typography>
           </Box>
 
-          <Divider sx={{ my: 2 }} />
+          {/* 種目リスト（チェックボックス方式） */}
+          <List>
+            {availableExercises.map(exercise => {
+              const isSelected = localConfig.exercises.includes(exercise);
+              const isDisabled = !isSelected && localConfig.exercises.length >= 5;
 
-          {/* 現在選択中種目セクション */}
-          <Box sx={{ mb: 2 }}>
-            <Typography variant="subtitle1" gutterBottom>
-              現在選択中の種目
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              選択中: {workoutConfig.exercises.length}/5種目
-            </Typography>
-
-            <List dense>
-              {workoutConfig.exercises.map((exercise, index) => (
-                <ListItem key={`${exercise}-${index}`} divider>
-                  <Box sx={{ display: 'flex', alignItems: 'center', mr: 1 }}>
+              return (
+                <ListItem
+                  key={exercise}
+                  onClick={() => !isDisabled && handleToggle(exercise)}
+                  sx={{
+                    cursor: isDisabled ? 'not-allowed' : 'pointer',
+                    opacity: isDisabled ? 0.5 : 1,
+                    '&:hover': {
+                      backgroundColor: isDisabled ? 'transparent' : 'action.hover',
+                    },
+                  }}
+                >
+                  <Checkbox
+                    edge="start"
+                    checked={isSelected}
+                    disabled={isDisabled}
+                    tabIndex={-1}
+                    disableRipple
+                  />
+                  <ListItemIcon>
                     {isCardioExercise(exercise) ? (
                       <RunIcon color="secondary" fontSize="small" />
                     ) : (
                       <FitnessCenterIcon color="primary" fontSize="small" />
                     )}
-                  </Box>
+                  </ListItemIcon>
                   <ListItemText
                     primary={exercise}
-                    secondary={
-                      isCardioExercise(exercise)
-                        ? 'カーディオ'
-                        : `筋トレ (${workoutConfig.maxSets}セット)`
-                    }
+                    secondary={isCardioExercise(exercise) ? 'カーディオ' : '筋トレ'}
                   />
-                  <ListItemSecondaryAction>
-                    <IconButton
-                      edge="end"
-                      size="small"
-                      onClick={() => removeExercise(exercise)}
-                      color="error"
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </ListItemSecondaryAction>
                 </ListItem>
-              ))}
-            </List>
-          </Box>
+              );
+            })}
+          </List>
 
-          <Divider sx={{ my: 2 }} />
+          <Divider sx={{ my: 3 }} />
 
-          {/* セット数変更セクション */}
-          <Box sx={{ mb: 3 }}>
+          {/* セット数設定 */}
+          <Box>
             <Typography variant="subtitle1" gutterBottom>
               筋トレ設定
             </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              筋トレ種目の最大セット数を設定
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              筋トレ種目の最大セット数
             </Typography>
-
-            <Box sx={{ px: 2 }}>
-              <Typography variant="body2" gutterBottom>
-                最大セット数: {workoutConfig.maxSets}
+            <Box sx={{ px: 2, mt: 2 }}>
+              <Typography gutterBottom>
+                最大セット数: {localConfig.maxSets}
               </Typography>
               <Slider
-                value={workoutConfig.maxSets}
-                onChange={(event, value) => updateMaxSets(value)}
+                value={localConfig.maxSets}
                 min={1}
                 max={5}
-                step={1}
-                marks={[
-                  { value: 1, label: '1' },
-                  { value: 2, label: '2' },
-                  { value: 3, label: '3' },
-                  { value: 4, label: '4' },
-                  { value: 5, label: '5' },
-                ]}
+                marks
                 valueLabelDisplay="auto"
-                sx={{ mb: 2 }}
+                onChange={handleMaxSetsChange}
               />
             </Box>
           </Box>
-
-          <Divider sx={{ my: 2 }} />
-
-          {/* 種目追加セクション */}
-          {workoutConfig.exercises.length >= 5 ? (
-            <Box sx={{ mb: 2, textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                📝 種目は最大3つまで選択可能です
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                種目を変更したい場合は、現在の種目を削除してください
-              </Typography>
-            </Box>
-          ) : (
-            <Box sx={{ mb: 2 }}>
-              <Typography variant="subtitle1" gutterBottom>
-                種目追加
-              </Typography>
-              <List dense sx={{ maxHeight: 200, overflow: 'auto' }}>
-                {availableToAdd.map(exercise => (
-                  <ListItem key={exercise} divider>
-                    <Box sx={{ display: 'flex', alignItems: 'center', mr: 1 }}>
-                      {isCardioExercise(exercise) ? (
-                        <RunIcon color="secondary" fontSize="small" />
-                      ) : (
-                        <FitnessCenterIcon color="primary" fontSize="small" />
-                      )}
-                    </Box>
-                    <ListItemText
-                      primary={exercise}
-                      secondary={
-                        isCardioExercise(exercise) ? 'カーディオ' : '筋トレ'
-                      }
-                    />
-                    <ListItemSecondaryAction>
-                      <IconButton
-                        edge="end"
-                        size="small"
-                        onClick={() => addExercise(exercise)}
-                        color="primary"
-                      >
-                        <AddIcon />
-                      </IconButton>
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                ))}
-              </List>
-            </Box>
-          )}
         </Box>
 
-        {/* フッター */}
-        <Box
-          sx={{
-            p: 2,
-            borderTop: '1px solid',
-            borderColor: 'divider',
-            bgcolor: 'background.paper',
-          }}
-        >
-          <Button variant="contained" fullWidth onClick={onClose} size="large">
+        {/* Footer */}
+        <Box sx={{ p: 2, display: 'flex', gap: 2, borderTop: 1, borderColor: 'divider' }}>
+          <Button variant="outlined" fullWidth onClick={handleCancel}>
+            キャンセル
+          </Button>
+          <Button
+            variant="contained"
+            fullWidth
+            onClick={handleSave}
+            disabled={localConfig.exercises.length === 0}
+          >
             設定を適用
           </Button>
         </Box>


### PR DESCRIPTION
FormConfigDrawerと同じ編集モードパターンを採用:
- localConfigで一時的な変更を管理（下書き機能）
- 保存/キャンセルによる明確な操作フロー
- チェックボックス方式の種目選択UI
- プリセット機能を削除してシンプル化

破壊的変更:
- props: addExercise/removeExercise → updateExercises/updateMaxSets
- プリセット機能の完全削除

🤖 Generated with [Claude Code](https://claude.ai/code)