### PR TITLE
fix(strava):詳細デバッグログ追加とUI表示の詳細化

### DIFF
--- a/frontend/src/components/strava/StravaSync.jsx
+++ b/frontend/src/components/strava/StravaSync.jsx
@@ -167,9 +167,16 @@ const StravaSync = () => {
                     {syncState.result.errorDetails && syncState.result.errorDetails.length > 0 && (
                       <Box sx={{ mt: 1, pl: 2 }}>
                         {syncState.result.errorDetails.map((err) => (
-                          <Typography key={`${err.activityId}-${err.activityName}`} variant="caption" color="error" component="div">
-                            - {err.activityName}: {err.error}
-                          </Typography>
+                          <Box key={`${err.activityId}-${err.activityName}`} sx={{ mb: 0.5 }}>
+                            <Typography variant="caption" color="error" component="div">
+                              - {err.activityName}: {err.error}
+                            </Typography>
+                            {err.type === 'duplicate_user' && (
+                              <Typography variant="caption" color="warning.main" component="div" sx={{ pl: 2 }}>
+                                ⚠️ 同じStravaアカウントを複数のユーザーで使用することはできません
+                              </Typography>
+                            )}
+                          </Box>
                         ))}
                       </Box>
                     )}


### PR DESCRIPTION
問題：
DBでアカウトの重複エラーが発生していても、UI側でエラー原因が表示されずエラー表示のみなのでデバッグとUXが低下している

修正：
backend: 同期ビジネスロジックに重複チェックのコードとエラー時の詳細ログ追加
errordetailsオブジェクトをresに格納
front:レスポンスresultからエラー時にrepsdetailを使用するロジックを追加